### PR TITLE
pal::expected<T,E> refactor

### DIFF
--- a/bench/expected.cpp
+++ b/bench/expected.cpp
@@ -28,12 +28,8 @@ struct value: public bench_base //{{{1
 
 	errc func (time_t &result)
 	{
-		if (code_path == errc::success)
-		{
-			result = time(nullptr);
-			return errc::success;
-		}
-		return errc::failure;
+		result = time(nullptr);
+		return code_path;
 	}
 
 	time_t run ()
@@ -56,11 +52,12 @@ struct exception: public bench_base //{{{1
 
 	time_t func ()
 	{
-		if (code_path == errc::success)
+		auto result = time(nullptr);
+		if (code_path == errc::failure)
 		{
-			return time(nullptr);
+			throw std::exception{};
 		}
-		throw std::exception{};
+		return result;
 	}
 
 	time_t run ()
@@ -84,9 +81,10 @@ struct expected: public bench_base //{{{1
 
 	pal::expected<time_t, errc> func ()
 	{
+		auto result = time(nullptr);
 		if (code_path == errc::success)
 		{
-			return time(nullptr);
+			return result;
 		}
 		return pal::unexpected{errc::failure};
 	}
@@ -98,18 +96,9 @@ struct expected: public bench_base //{{{1
 };
 
 
-struct expected_throw: public bench_base //{{{1
+struct expected_throw: public expected //{{{1
 {
-	using bench_base::bench_base;
-
-	pal::expected<time_t, errc> func ()
-	{
-		if (code_path == errc::success)
-		{
-			return time(nullptr);
-		}
-		return pal::unexpected{errc::failure};
-	}
+	using expected::expected;
 
 	time_t run ()
 	{

--- a/bench/expected.cpp
+++ b/bench/expected.cpp
@@ -67,9 +67,7 @@ struct exception: public bench_base
 	{
 		try
 		{
-			auto result = func();
-			benchmark::DoNotOptimize(result);
-			return result;
+			return func();
 		}
 		catch (errc e)
 		{

--- a/pal/expected
+++ b/pal/expected
@@ -8,7 +8,6 @@
  */
 
 #include <pal/__bits/lib>
-#include <pal/uninitialized>
 #include <pal/assert>
 #include <stdexcept>
 #include <type_traits>

--- a/pal/expected
+++ b/pal/expected
@@ -660,10 +660,7 @@ struct expected_storage: expected_storage_base<T, E>
 			std::is_nothrow_copy_assignable_v<T>
 		)
 	{
-		if constexpr (!std::is_void_v<T>)
-		{
-			this->value = that.value;
-		}
+		this->value = that.value;
 	}
 
 
@@ -677,12 +674,7 @@ struct expected_storage: expected_storage_base<T, E>
 			)
 		)
 	{
-		if constexpr (std::is_void_v<T>)
-		{
-			unexpected_dtor();
-			this->has_value = true;
-		}
-		else if constexpr (std::is_nothrow_copy_constructible_v<T>)
+		if constexpr (std::is_nothrow_copy_constructible_v<T>)
 		{
 			unexpected_dtor();
 			value_ctor(that.value);
@@ -720,11 +712,7 @@ struct expected_storage: expected_storage_base<T, E>
 			)
 		)
 	{
-		if constexpr (std::is_void_v<T>)
-		{
-			unexpected_ctor(that.unexpected.value());
-		}
-		else if constexpr (std::is_nothrow_copy_constructible_v<E>)
+		if constexpr (std::is_nothrow_copy_constructible_v<E>)
 		{
 			value_dtor();
 			unexpected_ctor(that.unexpected.value());
@@ -794,10 +782,7 @@ struct expected_storage: expected_storage_base<T, E>
 			std::is_nothrow_move_assignable_v<T>
 		)
 	{
-		if constexpr (!std::is_void_v<T>)
-		{
-			this->value = std::move(that.value);
-		}
+		this->value = std::move(that.value);
 	}
 
 
@@ -808,12 +793,7 @@ struct expected_storage: expected_storage_base<T, E>
 			std::is_nothrow_move_constructible_v<T>
 		)
 	{
-		if constexpr (std::is_void_v<T>)
-		{
-			unexpected_dtor();
-			this->has_value = true;
-		}
-		else if constexpr (std::is_nothrow_move_constructible_v<T>)
+		if constexpr (std::is_nothrow_move_constructible_v<T>)
 		{
 			unexpected_dtor();
 			value_ctor(std::move(that.value));
@@ -842,11 +822,7 @@ struct expected_storage: expected_storage_base<T, E>
 			std::is_nothrow_move_constructible_v<E>
 		)
 	{
-		if constexpr (std::is_void_v<T>)
-		{
-			unexpected_ctor(std::move(that.unexpected.value()));
-		}
-		else if constexpr (std::is_nothrow_move_constructible_v<E>)
+		if constexpr (std::is_nothrow_move_constructible_v<E>)
 		{
 			value_dtor();
 			unexpected_ctor(std::move(that.unexpected.value()));

--- a/pal/expected
+++ b/pal/expected
@@ -19,11 +19,31 @@ __pal_begin
 
 /// \cond undocumented
 
+
 // unexpected<E> {{{1
 
 template <typename E>
 class unexpected
 {
+private:
+
+	template <typename U>
+	static constexpr bool constructible_from_value =
+		!std::is_same_v<std::remove_cvref_t<U>, std::in_place_t> &&
+		!std::is_same_v<std::remove_cvref_t<U>, unexpected<E>>;
+
+	template <typename U>
+	static constexpr bool convertible_from_unexpected_v =
+		!std::is_constructible_v<E, const unexpected<U> &> &&
+		!std::is_constructible_v<E, unexpected<U> &> &&
+		!std::is_constructible_v<E, const unexpected<U>> &&
+		!std::is_constructible_v<E, unexpected<U>> &&
+		!std::is_convertible_v<const unexpected<U> &, E> &&
+		!std::is_convertible_v<unexpected<U> &, E> &&
+		!std::is_convertible_v<const unexpected<U>, E> &&
+		!std::is_convertible_v<unexpected<U>, E>
+	;
+
 public:
 
 	static_assert(std::is_object_v<E>);
@@ -32,82 +52,54 @@ public:
 	using error_type = E;
 
 
-	// Constructors {{{2
+	//
+	// Constructors
+	//
 
 	constexpr unexpected (const unexpected &) = default;
 	constexpr unexpected (unexpected &&) = default;
 
 
-	template <
-		typename... Args,
-		typename = std::enable_if_t<std::is_constructible_v<E, Args...>>
-	>
-	constexpr explicit unexpected (std::in_place_t, Args &&...args)
+	template <typename... Args>
+		requires(std::is_constructible_v<E, Args...>)
+	explicit constexpr unexpected (std::in_place_t, Args &&...args)
 		: value_{std::forward<Args>(args)...}
 	{ }
 
 
-	template <
-		typename U = E,
-		typename = std::enable_if_t<
-			std::is_constructible_v<E, U> &&
-			!std::is_same_v<std::remove_cvref_t<U>, std::in_place_t> &&
-			!std::is_same_v<std::remove_cvref_t<U>, unexpected<E>>
-		>
-	>
-	constexpr explicit unexpected (U &&e)
+	template <typename U>
+		requires(std::is_constructible_v<E, U> && constructible_from_value<U>)
+	explicit constexpr unexpected (U &&e)
 		: value_{std::forward<U>(e)}
 	{ }
 
 
-	template <
-		typename U,
-		typename = std::enable_if_t<
-			std::is_constructible_v<E, const U &> &&
-			!std::is_constructible_v<E, unexpected<U> &> &&
-			!std::is_constructible_v<E, unexpected<U>> &&
-			!std::is_constructible_v<E, const unexpected<U> &> &&
-			!std::is_constructible_v<E, const unexpected<U>> &&
-			!std::is_convertible_v<unexpected<U> &, E> &&
-			!std::is_convertible_v<unexpected<U>, E> &&
-			!std::is_convertible_v<const unexpected<U> &, E> &&
-			!std::is_convertible_v<const unexpected<U>, E>
-		>
-	>
-	constexpr explicit(!std::is_convertible_v<const U &, E>) unexpected (const unexpected<U> &that)
+	template <typename U>
+		requires(std::is_constructible_v<E, const U &> && convertible_from_unexpected_v<U>)
+		explicit(!std::is_convertible_v<const U &, E>)
+	constexpr unexpected (const unexpected<U> &that)
 		: value_{that.value_}
 	{ }
 
 
-	template <
-		typename U,
-		typename = std::enable_if_t<
-			std::is_constructible_v<E, U> &&
-			!std::is_constructible_v<E, unexpected<U> &> &&
-			!std::is_constructible_v<E, unexpected<U>> &&
-			!std::is_constructible_v<E, const unexpected<U> &> &&
-			!std::is_constructible_v<E, const unexpected<U>> &&
-			!std::is_convertible_v<unexpected<U> &, E> &&
-			!std::is_convertible_v<unexpected<U>, E> &&
-			!std::is_convertible_v<const unexpected<U> &, E> &&
-			!std::is_convertible_v<const unexpected<U>, E>
-		>
-	>
-	constexpr explicit(!std::is_convertible_v<U, E>) unexpected (unexpected<U> &&that)
+	template <typename U>
+		requires(std::is_constructible_v<E, U> && convertible_from_unexpected_v<U>)
+		explicit(!std::is_convertible_v<U, E>)
+	constexpr unexpected (unexpected<U> &&that)
 		: value_{std::move(that.value_)}
 	{ }
 
 
-	// Assignments {{{2
+	//
+	// Assignments
+	//
 
 	constexpr unexpected &operator= (const unexpected &) = default;
 	constexpr unexpected &operator= (unexpected &&) = default;
 
 
-	template <
-		typename U = E,
-		typename = std::enable_if_t<std::is_assignable_v<E &, const U &>>
-	>
+	template <typename U = E>
+		requires(std::is_assignable_v<E, const U &>)
 	constexpr unexpected &operator= (const unexpected<U> &that)
 	{
 		unexpected{that.value()}.swap(*this);
@@ -115,10 +107,8 @@ public:
 	}
 
 
-	template <
-		typename U = E,
-		typename = std::enable_if_t<std::is_assignable_v<E &, U>>
-	>
+	template <typename U = E>
+		requires(std::is_assignable_v<E, U>)
 	constexpr unexpected &operator= (unexpected<U> &&that)
 	{
 		unexpected{std::move(that.value())}.swap(*this);
@@ -126,7 +116,9 @@ public:
 	}
 
 
-	// Observers {{{2
+	//
+	// Observers
+	//
 
 	constexpr const E &value () const & noexcept
 	{
@@ -152,9 +144,17 @@ public:
 	}
 
 
-	// Swap {{{2
+	//
+	// Swap
+	//
 
-	void swap (unexpected &that) noexcept(std::is_nothrow_swappable_v<E>)
+	void swap (unexpected &that)
+		noexcept(std::is_nothrow_swappable_v<E>)
+		#if !defined(__apple_build_version__)
+		requires(std::is_swappable_v<E>)
+		#else
+		// TODO: remove
+		#endif
 	{
 		using std::swap;
 		swap(value_, that.value_);
@@ -169,6 +169,7 @@ private:
 
 
 template <typename E> unexpected(E) -> unexpected<E>;
+template <typename E> unexpected(std::in_place_t, E) -> unexpected<E>;
 
 
 template <typename E1, typename E2>
@@ -185,11 +186,10 @@ constexpr bool operator!= (const unexpected<E1> &l, const unexpected<E2> &r)
 }
 
 
-template <
-	typename E,
-	typename = std::enable_if_t<std::is_swappable_v<E>>
->
-void swap (unexpected<E> &l, unexpected<E> &r) noexcept(noexcept(l.swap(r)))
+template <typename E>
+	requires(std::is_swappable_v<E>)
+void swap (unexpected<E> &l, unexpected<E> &r)
+	noexcept(noexcept(l.swap(r)))
 {
 	l.swap(r);
 }
@@ -216,11 +216,10 @@ class bad_expected_access<void>: public std::exception
 {
 public:
 
-	explicit bad_expected_access ()
-		: std::exception{}
-	{ }
+	bad_expected_access () = default;
+	virtual ~bad_expected_access() = default;
 
-	virtual const char *what () const noexcept override
+	const char *what () const noexcept override
 	{
 		return "bad expected access";
 	}
@@ -271,59 +270,38 @@ namespace __bits {
 template <typename T, typename E>
 struct expected_storage_base
 {
-	bool has_value;
+	bool has_value{true};
 	union
 	{
 		uninitialized<T> value;
 		uninitialized<E> unexpected;
 	};
 
-	explicit expected_storage_base (bool has_value)
+	explicit expected_storage_base (bool has_value) noexcept
 		: has_value{has_value}
 	{ }
-
-	constexpr void destruct ()
-	{
-		if (has_value)
-		{
-			value.destruct();
-		}
-		else
-		{
-			unexpected.destruct();
-		}
-	}
 };
 
 template <typename E>
 struct expected_storage_base<void, E>
 {
-	bool has_value;
+	bool has_value{true};
 	union
 	{
+		bool empty;
 		uninitialized<E> unexpected;
 	};
 
-	explicit expected_storage_base (bool has_value)
+	explicit expected_storage_base (bool has_value) noexcept
 		: has_value{has_value}
 	{ }
-
-	constexpr void destruct ()
-	{
-		if (!has_value)
-		{
-			unexpected.destruct();
-		}
-	}
 };
 
-template <
-	typename T,
-	typename E,
+template <typename T, typename E,
 	bool = std::is_copy_constructible_v<T> && std::is_copy_constructible_v<E>,
 	bool = std::is_move_constructible_v<T> && std::is_move_constructible_v<E>
 >
-struct expected_storage: public expected_storage_base<T, E>
+struct expected_storage: expected_storage_base<T, E>
 {
 	using expected_storage_base<T, E>::expected_storage_base;
 
@@ -332,52 +310,52 @@ struct expected_storage: public expected_storage_base<T, E>
 };
 
 template <typename T, typename E>
-struct expected_storage<T, E, true, true>: public expected_storage_base<T, E>
+struct expected_storage<T, E, true, true>: expected_storage_base<T, E>
 {
 	using expected_storage_base<T, E>::expected_storage_base;
 
 	expected_storage (const expected_storage &that)
-		: expected_storage_base<T, E>{that.has_value}
+		: expected_storage{that.has_value}
 	{
 		if (this->has_value)
 		{
-			this->value.construct(*that.value);
+			this->value.construct(that.value);
 		}
 		else
 		{
-			this->unexpected.construct(*that.unexpected);
+			this->unexpected.construct(that.unexpected);
 		}
 	}
 
 	expected_storage (expected_storage &&that)
-		: expected_storage_base<T, E>{that.has_value}
+		: expected_storage{that.has_value}
 	{
 		if (this->has_value)
 		{
-			this->value.construct(std::move(*that.value));
+			this->value.construct(std::move(that.value));
 		}
 		else
 		{
-			this->unexpected.construct(std::move(*that.unexpected));
+			this->unexpected.construct(std::move(that.unexpected));
 		}
 	}
 };
 
 template <typename T, typename E>
-struct expected_storage<T, E, true, false>: public expected_storage_base<T, E>
+struct expected_storage<T, E, true, false>: expected_storage_base<T, E>
 {
 	using expected_storage_base<T, E>::expected_storage_base;
 
 	expected_storage (const expected_storage &that)
-		: expected_storage_base<T, E>{that.has_value}
+		: expected_storage{that.has_value}
 	{
 		if (this->has_value)
 		{
-			this->value.construct(*that.value);
+			this->value.construct(that.value);
 		}
 		else
 		{
-			this->unexpected.construct(*that.unexpected);
+			this->unexpected.construct(that.unexpected);
 		}
 	}
 
@@ -385,28 +363,28 @@ struct expected_storage<T, E, true, false>: public expected_storage_base<T, E>
 };
 
 template <typename T, typename E>
-struct expected_storage<T, E, false, true>: public expected_storage_base<T, E>
+struct expected_storage<T, E, false, true>: expected_storage_base<T, E>
 {
 	using expected_storage_base<T, E>::expected_storage_base;
 
-	expected_storage (const expected_storage &) = delete;
+	expected_storage (const expected_storage &that) = delete;
 
 	expected_storage (expected_storage &&that)
-		: expected_storage_base<T, E>{that.has_value}
+		: expected_storage{that.has_value}
 	{
 		if (this->has_value)
 		{
-			this->value.construct(std::move(*that.value));
+			this->value.construct(std::move(that.value));
 		}
 		else
 		{
-			this->unexpected.construct(std::move(*that.unexpected));
+			this->unexpected.construct(std::move(that.unexpected));
 		}
 	}
 };
 
 template <typename T, typename E>
-constexpr bool expected_is_swappable_v =
+static constexpr bool expected_is_swappable_v =
 	std::is_swappable_v<T> &&
 	std::is_swappable_v<E> &&
 	(
@@ -421,12 +399,13 @@ constexpr bool expected_is_swappable_v =
 ;
 
 template <typename E>
-constexpr bool expected_is_swappable_v<void, E> =
+static constexpr bool expected_is_swappable_v<void, E> =
 	std::is_swappable_v<E> &&
-	std::is_move_constructible_v<E>;
+	std::is_move_constructible_v<E>
+;
 
 template <typename T, typename E>
-constexpr bool expected_is_nothrow_swappable_v =
+static constexpr bool expected_is_nothrow_swappable_v =
 	std::is_nothrow_move_constructible_v<T> &&
 	std::is_nothrow_swappable_v<T> &&
 	std::is_nothrow_move_constructible_v<E> &&
@@ -434,7 +413,7 @@ constexpr bool expected_is_nothrow_swappable_v =
 ;
 
 template <typename E>
-constexpr bool expected_is_nothrow_swappable_v<void, E> =
+static constexpr bool expected_is_nothrow_swappable_v<void, E> =
 	std::is_nothrow_move_constructible_v<E> &&
 	std::is_nothrow_swappable_v<E>
 ;
@@ -447,7 +426,38 @@ constexpr bool expected_is_nothrow_swappable_v<void, E> =
 template <typename T, typename E>
 class expected
 {
+private:
+
+	template <typename U, typename G>
+	static constexpr bool converts_from_expected_v =
+		//
+		std::is_constructible_v<T, const expected<U, G> &> ||
+		std::is_constructible_v<T,       expected<U, G> &> ||
+		std::is_constructible_v<T, const expected<U, G> &&> ||
+		std::is_constructible_v<T,       expected<U, G> &&> ||
+		//
+		std::is_convertible_v<const expected<U, G> &,  T> ||
+		std::is_convertible_v<      expected<U, G> &,  T> ||
+		std::is_convertible_v<const expected<U, G> &&, T> ||
+		std::is_convertible_v<      expected<U, G> &&, T> ||
+		//
+		std::is_constructible_v<unexpected<E>, const expected<U, G> &> ||
+		std::is_constructible_v<unexpected<E>,       expected<U, G> &> ||
+		std::is_constructible_v<unexpected<E>, const expected<U, G> &&> ||
+		std::is_constructible_v<unexpected<E>,       expected<U, G> &&> ||
+		//
+		std::is_convertible_v<const expected<U, G> &,  unexpected<E>> ||
+		std::is_convertible_v<      expected<U, G> &,  unexpected<E>> ||
+		std::is_convertible_v<const expected<U, G> &&, unexpected<E>> ||
+		std::is_convertible_v<      expected<U, G> &&, unexpected<E>>
+	;
+
 public:
+
+	static_assert(!std::is_reference_v<T>);
+	static_assert(!std::is_same_v<std::remove_cv_t<T>, std::in_place_t>);
+	static_assert(!std::is_same_v<std::remove_cv_t<T>, unexpect_t>);
+	static_assert(!std::is_same_v<std::remove_cv_t<T>, unexpected<E>>);
 
 	using value_type = T;
 	using error_type = E;
@@ -457,15 +467,12 @@ public:
 	using rebind = expected<U, error_type>;
 
 
-	// Constructors {{{2
+	//
+	// Constructors
+	//
 
-	template <
-		typename U = T,
-		typename = std::enable_if_t<
-			std::is_default_constructible_v<U> ||
-			std::is_void_v<U>
-		>
-	>
+	template <typename U = T>
+		requires(std::is_default_constructible_v<U> || std::is_void_v<U>)
 	constexpr expected ()
 		: impl_{true}
 	{
@@ -479,92 +486,60 @@ public:
 	constexpr expected (const expected &) = default;
 	constexpr expected (expected &&) = default;
 
-	template <
-		typename U,
-		typename G,
-		typename = std::enable_if_t<
+
+	template <typename U, typename G>
+		requires
+		(
 			std::is_constructible_v<T, const U &> &&
 			std::is_constructible_v<E, const G &> &&
-
-			!std::is_constructible_v<T, expected<U, G> &> &&
-			!std::is_constructible_v<T, expected<U, G> &&> &&
-			!std::is_constructible_v<T, const expected<U, G> &> &&
-			!std::is_constructible_v<T, const expected<U, G> &&> &&
-
-			!std::is_convertible_v<expected<U, G> &, T> &&
-			!std::is_convertible_v<expected<U, G> &&, T> &&
-			!std::is_convertible_v<const expected<U, G> &, T> &&
-			!std::is_convertible_v<const expected<U, G> &&, T> &&
-
-			!std::is_convertible_v<expected<U, G> &, unexpected<E>> &&
-			!std::is_convertible_v<expected<U, G> &&, unexpected<E>> &&
-			!std::is_convertible_v<const expected<U, G> &, unexpected<E>> &&
-			!std::is_convertible_v<const expected<U, G> &&, unexpected<E>>
-		>
-	>
+			!converts_from_expected_v<U, G>
+		)
 	explicit(!std::is_convertible_v<const U &, T> || !std::is_convertible_v<const G &, E>)
 	constexpr expected (const expected<U, G> &that)
 		: impl_{that.has_value()}
 	{
 		if (impl_.has_value)
 		{
-			impl_.value.construct(static_cast<T>(*that));
+			impl_.value.construct(*that);
 		}
 		else
 		{
-			impl_.unexpected.construct(static_cast<E>(that.error()));
+			impl_.unexpected.construct(that.error());
 		}
 	}
 
 
-	template <
-		typename U,
-		typename G,
-		typename = std::enable_if_t<
+	template <typename U, typename G>
+		requires
+		(
 			std::is_constructible_v<T, U &&> &&
 			std::is_constructible_v<E, G &&> &&
-
-			!std::is_constructible_v<T, expected<U, G> &> &&
-			!std::is_constructible_v<T, expected<U, G> &&> &&
-			!std::is_constructible_v<T, const expected<U, G> &> &&
-			!std::is_constructible_v<T, const expected<U, G> &&> &&
-
-			!std::is_convertible_v<expected<U, G> &, T> &&
-			!std::is_convertible_v<expected<U, G> &&, T> &&
-			!std::is_convertible_v<const expected<U, G> &, T> &&
-			!std::is_convertible_v<const expected<U, G> &&, T> &&
-
-			!std::is_convertible_v<expected<U, G> &, unexpected<E>> &&
-			!std::is_convertible_v<expected<U, G> &&, unexpected<E>> &&
-			!std::is_convertible_v<const expected<U, G> &, unexpected<E>> &&
-			!std::is_convertible_v<const expected<U, G> &&, unexpected<E>>
-		>
-	>
+			!converts_from_expected_v<U, G>
+		)
 	explicit(!std::is_convertible_v<U &&, T> || !std::is_convertible_v<G &&, E>)
 	constexpr expected (expected<U, G> &&that)
 		: impl_{that.has_value()}
 	{
 		if (impl_.has_value)
 		{
-			impl_.value.construct(static_cast<T>(std::move(*that)));
+			impl_.value.construct(std::move(*that));
 		}
 		else
 		{
-			impl_.unexpected.construct(static_cast<E>(std::move(that.error())));
+			impl_.unexpected.construct(std::move(that.error()));
 		}
 	}
 
 
-	template <
-		typename U = T,
-		typename = std::enable_if_t<
-			!std::is_void_v<T> &&
-			std::is_constructible_v<T, U&&> &&
+	template <typename U = T>
+		requires
+		(
+			!std::is_void_v<U> &&
+			std::is_constructible_v<T, U &&> &&
 			!std::is_same_v<std::remove_cvref_t<U>, std::in_place_t> &&
-			!std::is_same_v<expected<T, E>, std::remove_cvref_t<U>> &&
-			!std::is_same_v<unexpected<E>, std::remove_cvref_t<U>>
-		>
-	>
+			!std::is_same_v<std::remove_cvref_t<U>, expected<T, E>> &&
+			!std::is_same_v<std::remove_cvref_t<U>, unexpected<E>>
+		)
 	explicit(!std::is_convertible_v<U &&, T>)
 	constexpr expected (U &&v)
 		: impl_{true}
@@ -573,37 +548,33 @@ public:
 	}
 
 
-	template <
-		typename G = E,
-		typename = std::enable_if_t<std::is_constructible_v<E, const G &>>
-	>
+	template <typename G = E>
+		requires(std::is_constructible_v<E, const G &>)
 	explicit(!std::is_convertible_v<const G &, E>)
 	constexpr expected (const unexpected<G> &e)
 		: impl_{false}
 	{
-		impl_.unexpected.construct(static_cast<E>(e.value()));
+		impl_.unexpected.construct(e.value());
 	}
 
 
-	template <
-		typename G = E,
-		typename = std::enable_if_t<std::is_constructible_v<E, G &&>>
-	>
+	template <typename G = E>
+		requires(std::is_constructible_v<E, G &&>)
 	explicit(!std::is_convertible_v<G &&, E>)
-	constexpr expected (unexpected<G> &&e) noexcept(std::is_nothrow_constructible_v<E, G&&>)
+	constexpr expected (unexpected<G> &&e)
+		noexcept(std::is_nothrow_constructible_v<E, G &&>)
 		: impl_{false}
 	{
-		impl_.unexpected.construct(std::move(static_cast<E>(e.value())));
+		impl_.unexpected.construct(std::move(e.value()));
 	}
 
 
-	template <
-		typename... Args,
-		typename = std::enable_if_t<
+	template <typename... Args>
+		requires
+		(
 			(std::is_void_v<T> && sizeof...(Args) == 0) ||
 			(!std::is_void_v<T> && std::is_constructible_v<T, Args...>)
-		>
-	>
+		)
 	explicit constexpr expected (std::in_place_t, Args &&...args)
 		: impl_{true}
 	{
@@ -614,24 +585,42 @@ public:
 	}
 
 
-	template <
-		typename... Args,
-		typename = std::enable_if_t<std::is_constructible_v<E, Args...>>
-	>
-	explicit constexpr expected (unexpect_t, Args &&...args)
+	template <typename... Args>
+		requires(std::is_constructible_v<E, Args...>)
+	explicit expected (unexpect_t, Args &&...args)
+		noexcept(std::is_nothrow_constructible_v<E, Args...>)
 		: impl_{false}
 	{
 		impl_.unexpected.construct(std::forward<Args>(args)...);
 	}
 
 
+	//
+	// Destructor
+	//
+
 	~expected ()
 	{
-		impl_.destruct();
+		if (impl_.has_value)
+		{
+			if constexpr (!std::is_void_v<T> && !std::is_trivially_destructible_v<T>)
+			{
+				impl_.value.destruct();
+			}
+		}
+		else
+		{
+			if constexpr (!std::is_trivially_destructible_v<E>)
+			{
+				impl_.unexpected.destruct();
+			}
+		}
 	}
 
 
-	// Assignments {{{2
+	//
+	// Assignment
+	//
 
 	expected &operator= (const expected &that)
 		noexcept
@@ -723,29 +712,6 @@ public:
 	}
 
 
-	template <
-		typename U = T,
-		typename G = E,
-		typename = std::enable_if_t<
-			(
-				std::is_void_v<U> &&
-				std::is_move_constructible_v<G> &&
-				std::is_move_assignable_v<G>
-			)
-			||
-			(
-				!std::is_void_v<U> &&
-				std::is_move_constructible_v<U> &&
-				std::is_move_assignable_v<U> &&
-				std::is_move_constructible_v<G> &&
-				std::is_move_assignable_v<G> &&
-				(
-					std::is_nothrow_move_constructible_v<U> ||
-					std::is_nothrow_move_constructible_v<G>
-				)
-			)
-		>
-	>
 	expected &operator= (expected &&that)
 		noexcept
 		(
@@ -790,7 +756,7 @@ public:
 		}
 		else if (impl_.has_value)
 		{
-			if constexpr (std::is_void_v<U>)
+			if constexpr (std::is_void_v<T>)
 			{
 				impl_.unexpected.construct(std::move(*that.impl_.unexpected));
 			}
@@ -823,13 +789,12 @@ public:
 	}
 
 
-	template <
-		typename G = E,
-		typename = std::enable_if_t<
+	template <typename G = E>
+		requires
+		(
 			std::is_nothrow_copy_constructible_v<G> &&
 			std::is_copy_assignable_v<G>
-		>
-	>
+		)
 	expected &operator= (const unexpected<G> &e)
 	{
 		if (impl_.has_value)
@@ -849,13 +814,12 @@ public:
 	}
 
 
-	template <
-		typename G = E,
-		typename = std::enable_if_t<
+	template <typename G = E>
+		requires
+		(
 			std::is_nothrow_move_constructible_v<G> &&
 			std::is_move_assignable_v<G>
-		>
-	>
+		)
 	expected &operator= (unexpected<G> &&e)
 	{
 		if (impl_.has_value)
@@ -875,17 +839,16 @@ public:
 	}
 
 
-	template <
-		typename U = T,
-		typename = std::enable_if_t<
+	template <typename U = T>
+		requires
+		(
 			!std::is_void_v<T> &&
 			!std::is_same_v<expected<T, E>, std::remove_cvref_t<U>> &&
 			!std::conjunction_v<std::is_scalar<T>, std::is_same<T, std::decay_t<U>>> &&
 			std::is_constructible_v<T, U> &&
 			std::is_assignable_v<std::add_lvalue_reference_t<T>, U> &&
 			std::is_nothrow_move_constructible_v<E>
-		>
-	>
+		)
 	expected &operator= (U &&v)
 	{
 		if (impl_.has_value)
@@ -920,10 +883,8 @@ public:
 	}
 
 
-	template <
-		typename U = T,
-		typename = std::enable_if_t<std::is_void_v<U>>
-	>
+	template <typename U = T>
+		requires(std::is_void_v<U>)
 	void emplace ()
 	{
 		if (!impl_.has_value)
@@ -934,11 +895,8 @@ public:
 	}
 
 
-	template <
-		typename U = T,
-		typename... Args,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
+	template <typename U = T, typename... Args>
+		requires(!std::is_void_v<U> && std::is_nothrow_constructible_v<T, Args...>)
 	U &emplace (Args &&...args)
 	{
 		if (impl_.has_value)
@@ -980,16 +938,14 @@ public:
 	}
 
 
-	// Swap {{{2
+	//
+	// Swap
+	//
 
-	template <
-		typename U = T,
-		typename G = E,
-		typename = std::enable_if_t<
-			__bits::expected_is_swappable_v<U, G>
-		>
-	>
-	void swap (expected &that) noexcept(__bits::expected_is_nothrow_swappable_v<U, G>)
+	template <typename U = T, typename G = E>
+		requires(__bits::expected_is_swappable_v<U, G>)
+	void swap (expected &that)
+		noexcept(__bits::expected_is_nothrow_swappable_v<U, G>)
 	{
 		using std::swap;
 		if (impl_.has_value && that.impl_.has_value)
@@ -1080,281 +1036,173 @@ public:
 	}
 
 
-	// Observers {{{2
-
-	template <
-		typename U = T,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
-	constexpr const U *operator-> () const
-	{
-		expect_value();
-		return impl_.value.operator->();
-	}
-
-	template <
-		typename U = T,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
-	constexpr U *operator-> ()
-	{
-		expect_value();
-		return impl_.value.operator->();
-	}
-
-	template <
-		typename U = T,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
-	constexpr const U &operator* () const &
-	{
-		expect_value();
-		return *operator->();
-	}
-
-	template <
-		typename U = T,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
-	constexpr U &operator* () &
-	{
-		expect_value();
-		return *operator->();
-	}
-
-	template <
-		typename U = T,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
-	constexpr const U &&operator* () const &&
-	{
-		expect_value();
-		return std::move(*operator->());
-	}
-
-	template <
-		typename U = T,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
-	constexpr U &&operator* () &&
-	{
-		expect_value();
-		return std::move(*operator->());
-	}
+	//
+	// Observers
+	//
 
 	constexpr bool has_value () const noexcept
 	{
 		return impl_.has_value;
 	}
 
+
 	constexpr explicit operator bool () const noexcept
 	{
 		return has_value();
 	}
 
-	template <
-		typename U = T,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
-	constexpr const U &value () const &
+
+	template <typename U = T>
+		requires(!std::is_void_v<U>)
+	constexpr const U *operator-> () const noexcept
 	{
-		if (impl_.has_value)
-		{
-			return **this;
-		}
-		throw bad_expected_access<E>(error());
+		return impl_.value.operator->();
 	}
 
-	template <
-		typename U = T,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
-	constexpr U &value () &
+
+	template <typename U = T>
+		requires(!std::is_void_v<U>)
+	constexpr U *operator-> () noexcept
 	{
-		if (impl_.has_value)
-		{
-			return **this;
-		}
-		throw bad_expected_access<E>(error());
+		return impl_.value.operator->();
 	}
 
-	template <
-		typename U = T,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
-	constexpr const U &&value () const &&
+
+	template <typename U = T>
+		requires(!std::is_void_v<U>)
+	constexpr const U &operator* () const &
 	{
-		if (impl_.has_value)
-		{
-			return std::move(**this);
-		}
-		throw bad_expected_access<E>(std::move(error()));
+		return impl_.value.operator*();
 	}
 
-	template <
-		typename U = T,
-		typename = std::enable_if_t<!std::is_void_v<U>>
-	>
-	constexpr U &&value () &&
+
+	template <typename U = T>
+		requires(!std::is_void_v<U>)
+	constexpr U &operator* () &
 	{
-		if (impl_.has_value)
-		{
-			return std::move(**this);
-		}
-		throw bad_expected_access<E>(std::move(error()));
+		return impl_.value.operator*();
 	}
+
+
+	template <typename U = T>
+		requires(!std::is_void_v<U>)
+	constexpr const U &&operator* () const &&
+	{
+		return std::move(impl_.value.operator*());
+	}
+
+
+	template <typename U = T>
+		requires(!std::is_void_v<U>)
+	constexpr U &&operator* () &&
+	{
+		return std::move(impl_.value.operator*());
+	}
+
 
 	constexpr const E &error () const &
 	{
-		expect_error();
 		return impl_.unexpected->value();
 	}
+
 
 	constexpr E &error () &
 	{
-		expect_error();
 		return impl_.unexpected->value();
 	}
 
+
 	constexpr const E &&error () const &&
 	{
-		expect_error();
 		return std::move(impl_.unexpected->value());
 	}
+
 
 	constexpr E &&error () &&
 	{
-		expect_error();
 		return std::move(impl_.unexpected->value());
 	}
 
-	template <
-		typename U,
-		typename = std::enable_if_t<
-			std::is_copy_constructible_v<T> &&
-			std::is_convertible_v<U &&, T>
-		>
-	>
-	constexpr T value_or (U &&v) const &
+
+	template <typename U = T>
+		requires(!std::is_void_v<U>)
+	constexpr const U &value () const &
 	{
-		return bool(*this) ? **this : static_cast<T>(std::forward<U>(v));
+		return require_value(), impl_.value.get();
 	}
 
-	template <
-		typename U,
-		typename = std::enable_if_t<
-			std::is_move_constructible_v<T> &&
-			std::is_convertible_v<U &&, T>
-		>
-	>
+
+	template <typename U = T>
+		requires(!std::is_void_v<U>)
+	constexpr U &value () &
+	{
+		return require_value(), impl_.value.get();
+	}
+
+
+	template <typename U = T>
+		requires(!std::is_void_v<U>)
+	constexpr const U &&value () const &&
+	{
+		return require_value(), std::move(impl_.value.get());
+	}
+
+
+	template <typename U = T>
+		requires(!std::is_void_v<U>)
+	constexpr U &&value () &&
+	{
+		return require_value(), std::move(impl_.value.get());
+	}
+
+
+	template <typename U>
+		requires(std::is_copy_constructible_v<T> && std::is_convertible_v<U&&, T>)
+	constexpr T value_or (U &&v) const &
+	{
+		return impl_.has_value
+			? impl_.value.get()
+			: static_cast<T>(std::forward<U>(v))
+		;
+	}
+
+
+	template <typename U>
+		requires(std::is_move_constructible_v<T> && std::is_convertible_v<U&&, T>)
 	constexpr T value_or (U &&v) &&
 	{
-		return bool(*this) ? std::move(**this) : static_cast<T>(std::forward<U>(v));
+		return impl_.has_value
+			? std::move(impl_.value.get())
+			: static_cast<T>(std::forward<U>(v))
+		;
 	}
 
 
 private:
 
-	__bits::expected_storage<T, unexpected_type> impl_;
+	__bits::expected_storage<T, unexpected_type> impl_{};
 
-	constexpr void expect_value () const
+	constexpr bool require_value () const &
 	{
-		pal_assert(impl_.has_value);
-	}
-
-	constexpr void expect_error () const
-	{
-		pal_assert(!impl_.has_value);
+		if (!impl_.has_value)
+		{
+			throw bad_expected_access<E>(error());
+		}
+		return impl_.has_value;
 	}
 };
 
 
-template <typename T, typename E, typename U, typename G>
-constexpr bool operator== (const expected<T, E> &l, const expected<U, G> &r)
-{
-	if (l.has_value() && r.has_value())
-	{
-		if constexpr (std::is_void_v<T> && std::is_void_v<U>)
-		{
-			return true;
-		}
-		else
-		{
-			return *l == *r;
-		}
-	}
-	else if (!l.has_value() && !r.has_value())
-	{
-		return l.error() == r.error();
-	}
-	return false;
-}
-
-template <typename T, typename E, typename U, typename G>
-constexpr bool operator!= (const expected<T, E> &l, const expected<U, G> &r)
-{
-	return !(l == r);
-}
-
-template <typename T, typename E, typename U>
-constexpr bool operator== (const expected<T, E> &l, const U &r)
-{
-	return l.has_value() && *l == r;
-}
-
-template <typename T, typename E, typename U>
-constexpr bool operator== (const U &l, const expected<T, E> &r)
-{
-	return r == l;
-}
-
-template <typename T, typename E, typename U>
-constexpr bool operator!= (const expected<T, E> &l, const U &r)
-{
-	return !(l == r);
-}
-
-template <typename T, typename E, typename U>
-constexpr bool operator!= (const U &l, const expected<T, E> &r)
-{
-	return r != l;
-}
-
-template <typename T, typename E, typename G>
-constexpr bool operator== (const expected<T, E> &l, const unexpected<G> &r)
-{
-	return !l.has_value() && l.error() == r.value();
-}
-
-template <typename T, typename E, typename G>
-constexpr bool operator== (const unexpected<G> &l, const expected<T, E> &r)
-{
-	return r == l;
-}
-
-template <typename T, typename E, typename G>
-constexpr bool operator!= (const expected<T, E> &l, const unexpected<G> &r)
-{
-	return l.has_value() || l.error() != r.value();
-}
-
-template <typename T, typename E, typename G>
-constexpr bool operator!= (const unexpected<G> &l, const expected<T, E> &r)
-{
-	return r != l;
-}
-
-template <
-	typename T,
-	typename E,
-	typename = std::enable_if_t<__bits::expected_is_swappable_v<T, E>>
->
-void swap (expected<T, E> &l, expected<T, E> &r) noexcept(noexcept(l.swap(r)))
+template <typename T, typename E>
+	requires(__bits::expected_is_swappable_v<T, E>)
+void swap (expected<T, E> &l, expected<T, E> &r)
+	noexcept(noexcept(l.swap(r)))
 {
 	l.swap(r);
 }
 
 //}}}1
+
 
 /// \endcond
 

--- a/pal/expected
+++ b/pal/expected
@@ -4,7 +4,7 @@
  * \file pal/expected
  * Temporary std::expected implementation until standardized.
  *
- * \see www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0323r9.html
+ * \see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0323r9.html
  */
 
 #include <pal/__bits/lib>
@@ -20,8 +20,11 @@ __pal_begin
 /// \cond undocumented
 
 
-// unexpected<E> {{{1
+template <typename T, typename E>
+class expected;
 
+
+// unexpected<E> {{{1
 template <typename E>
 class unexpected
 {
@@ -63,6 +66,7 @@ public:
 	template <typename... Args>
 		requires(std::is_constructible_v<E, Args...>)
 	explicit constexpr unexpected (std::in_place_t, Args &&...args)
+		noexcept(std::is_nothrow_constructible_v<E, Args...>)
 		: value_{std::forward<Args>(args)...}
 	{ }
 
@@ -70,6 +74,7 @@ public:
 	template <typename U>
 		requires(std::is_constructible_v<E, U> && constructible_from_value<U>)
 	explicit constexpr unexpected (U &&e)
+		noexcept(std::is_nothrow_constructible_v<E, U>)
 		: value_{std::forward<U>(e)}
 	{ }
 
@@ -78,6 +83,7 @@ public:
 		requires(std::is_constructible_v<E, const U &> && convertible_from_unexpected_v<U>)
 		explicit(!std::is_convertible_v<const U &, E>)
 	constexpr unexpected (const unexpected<U> &that)
+		noexcept(std::is_nothrow_constructible_v<E, const U &>)
 		: value_{that.value_}
 	{ }
 
@@ -86,6 +92,7 @@ public:
 		requires(std::is_constructible_v<E, U> && convertible_from_unexpected_v<U>)
 		explicit(!std::is_convertible_v<U, E>)
 	constexpr unexpected (unexpected<U> &&that)
+		noexcept(std::is_nothrow_constructible_v<E, U &&>)
 		: value_{std::move(that.value_)}
 	{ }
 
@@ -151,9 +158,9 @@ public:
 	void swap (unexpected &that)
 		noexcept(std::is_nothrow_swappable_v<E>)
 		#if !defined(__apple_build_version__)
-		requires(std::is_swappable_v<E>)
+			requires(std::is_swappable_v<E>)
 		#else
-		// TODO: remove
+			// TODO: expected ';' at end of declaration list
 		#endif
 	{
 		using std::swap;
@@ -196,7 +203,6 @@ void swap (unexpected<E> &l, unexpected<E> &r)
 
 
 // unexpect_t {{{1
-
 struct unexpect_t
 {
 	explicit unexpect_t () = default;
@@ -206,7 +212,6 @@ inline constexpr unexpect_t unexpect{};
 
 
 // bad_expected_access {{{1
-
 template <typename E>
 class bad_expected_access;
 
@@ -264,124 +269,836 @@ private:
 
 
 // expected<T, E> internals {{{1
-
 namespace __bits {
 
-template <typename T, typename E>
+struct no_init_t {};
+constexpr no_init_t no_init;
+
+constexpr int deleted_v = 0;
+constexpr int non_trivial_v = 1;
+constexpr int trivial_v = 2;
+
+// expected_storage_base {{{2
+
+// non-trivial T, non-trivial E {{{3
+template <typename T, typename E,
+	bool = std::is_trivially_destructible_v<T>,
+	bool = std::is_trivially_destructible_v<E>
+>
 struct expected_storage_base
 {
-	bool has_value{true};
+	bool has_value;
 	union
 	{
-		uninitialized<T> value;
-		uninitialized<E> unexpected;
+		T value;
+		pal::unexpected<E> unexpected;
+		no_init_t no_init;
 	};
 
-	explicit expected_storage_base (bool has_value) noexcept
-		: has_value{has_value}
+	constexpr expected_storage_base () noexcept
+		: has_value{true}
+		, value{}
 	{ }
+
+	constexpr expected_storage_base (no_init_t) noexcept
+		: has_value{false}
+		, no_init{}
+	{ }
+
+	template <typename... Args>
+		requires(std::is_constructible_v<T, Args &&...>)
+	constexpr expected_storage_base (std::in_place_t, Args &&...args)
+		: has_value{true}
+		, value{std::forward<Args>(args)...}
+	{ }
+
+	template <typename... Args>
+		requires(std::is_constructible_v<E, Args &&...>)
+	constexpr expected_storage_base (unexpect_t, Args &&...args)
+		: has_value{false}
+		, unexpected{std::forward<Args>(args)...}
+	{ }
+
+	~expected_storage_base ()
+	{
+		if (has_value)
+		{
+			value.~T();
+		}
+		else
+		{
+			unexpected.~unexpected<E>();
+		}
+	}
 };
 
-template <typename E>
-struct expected_storage_base<void, E>
+// trivial T, trivial E {{{3
+template <typename T, typename E>
+struct expected_storage_base<T, E, true, true>
 {
-	bool has_value{true};
+	bool has_value;
+	union
+	{
+		T value;
+		pal::unexpected<E> unexpected;
+		no_init_t no_init;
+	};
+
+	constexpr expected_storage_base () noexcept
+		: has_value{true}
+		, value{}
+	{ }
+
+	constexpr expected_storage_base (no_init_t) noexcept
+		: has_value{false}
+		, no_init{}
+	{ }
+
+	template <typename... Args>
+		requires(std::is_constructible_v<T, Args &&...>)
+	constexpr expected_storage_base (std::in_place_t, Args &&...args)
+		: has_value{true}
+		, value{std::forward<Args>(args)...}
+	{ }
+
+	template <typename... Args>
+		requires(std::is_constructible_v<E, Args &&...>)
+	constexpr expected_storage_base (unexpect_t, Args &&...args)
+		: has_value{false}
+		, unexpected{std::forward<Args>(args)...}
+	{ }
+
+	expected_storage_base (const expected_storage_base &) = default;
+	expected_storage_base (expected_storage_base &&) = default;
+	expected_storage_base &operator= (const expected_storage_base &) = default;
+	expected_storage_base &operator= (expected_storage_base &&) = default;
+	~expected_storage_base () = default;
+};
+
+// trivial T, non-trivial E {{{3
+template <typename T, typename E>
+struct expected_storage_base<T, E, true, false>
+{
+	bool has_value;
+	union
+	{
+		T value;
+		pal::unexpected<E> unexpected;
+		no_init_t no_init;
+	};
+
+	constexpr expected_storage_base () noexcept
+		: has_value{true}
+		, value{}
+	{ }
+
+	constexpr expected_storage_base (no_init_t) noexcept
+		: has_value{false}
+		, no_init{}
+	{ }
+
+	template <typename... Args>
+		requires(std::is_constructible_v<T, Args &&...>)
+	constexpr expected_storage_base (std::in_place_t, Args &&...args)
+		: has_value{true}
+		, value{std::forward<Args>(args)...}
+	{ }
+
+	template <typename... Args>
+		requires(std::is_constructible_v<E, Args &&...>)
+	constexpr expected_storage_base (unexpect_t, Args &&...args)
+		: has_value{false}
+		, unexpected{std::forward<Args>(args)...}
+	{ }
+
+	~expected_storage_base ()
+	{
+		if (!has_value)
+		{
+			unexpected.~unexpected<E>();
+		}
+	}
+};
+
+// non-trivial T, trivial E {{{3
+template <typename T, typename E>
+struct expected_storage_base<T, E, false, true>
+{
+	bool has_value;
+	union
+	{
+		T value;
+		pal::unexpected<E> unexpected;
+		no_init_t no_init;
+	};
+
+	constexpr expected_storage_base () noexcept
+		: has_value{true}
+		, value{}
+	{ }
+
+	constexpr expected_storage_base (no_init_t) noexcept
+		: has_value{false}
+		, no_init{}
+	{ }
+
+	template <typename... Args>
+		requires(std::is_constructible_v<T, Args &&...>)
+	constexpr expected_storage_base (std::in_place_t, Args &&...args)
+		: has_value{true}
+		, value{std::forward<Args>(args)...}
+	{ }
+
+	template <typename... Args>
+		requires(std::is_constructible_v<E, Args &&...>)
+	constexpr expected_storage_base (unexpect_t, Args &&...args)
+		: has_value{false}
+		, unexpected{std::forward<Args>(args)...}
+	{ }
+
+	~expected_storage_base ()
+	{
+		if (has_value)
+		{
+			value.~T();
+		}
+	}
+};
+
+// void T, non-trivial E {{{3
+template <typename E>
+struct expected_storage_base<void, E, false, false>
+{
+	bool has_value;
 	union
 	{
 		bool empty;
-		uninitialized<E> unexpected;
+		pal::unexpected<E> unexpected;
+		no_init_t no_init;
 	};
 
-	explicit expected_storage_base (bool has_value) noexcept
-		: has_value{has_value}
+	constexpr expected_storage_base () noexcept
+		: has_value{true}
+		, empty{}
 	{ }
+
+	constexpr expected_storage_base (no_init_t) noexcept
+		: has_value{false}
+		, no_init{}
+	{ }
+
+	constexpr expected_storage_base (std::in_place_t)
+		: has_value{true}
+		, empty{}
+	{ }
+
+	template <typename... Args>
+		requires(std::is_constructible_v<E, Args &&...>)
+	constexpr expected_storage_base (unexpect_t, Args &&...args)
+		: has_value{false}
+		, unexpected{std::forward<Args>(args)...}
+	{ }
+
+	expected_storage_base (const expected_storage_base &that)
+		: has_value{that.has_value}
+	{
+		if (!has_value)
+		{
+			new(std::addressof(unexpected)) pal::unexpected<E>{that.unexpected};
+		}
+	}
+
+	expected_storage_base &operator= (const expected_storage_base &that)
+	{
+		if (has_value && that.has_value)
+		{
+		}
+		else if (!has_value && that.has_value)
+		{
+			unexpected.~unexpected<E>();
+			has_value = true;
+		}
+		else if (has_value)
+		{
+			new(std::addressof(unexpected)) pal::unexpected<E>{that.unexpected.value()};
+			has_value = false;
+		}
+		else
+		{
+			unexpected.value() = that.unexpected.value();
+		}
+		return *this;
+	}
+
+	~expected_storage_base ()
+	{
+		if (!has_value)
+		{
+			unexpected.~unexpected<E>();
+		}
+	}
 };
 
-template <typename T, typename E,
-	bool = std::is_copy_constructible_v<T> && std::is_copy_constructible_v<E>,
-	bool = std::is_move_constructible_v<T> && std::is_move_constructible_v<E>
->
+// void T, trivial E {{{3
+template <typename E>
+struct expected_storage_base<void, E, false, true>
+{
+	bool has_value;
+	union
+	{
+		bool empty;
+		pal::unexpected<E> unexpected;
+		no_init_t no_init;
+	};
+
+	constexpr expected_storage_base () noexcept
+		: has_value{true}
+		, empty{}
+	{ }
+
+	constexpr expected_storage_base (no_init_t) noexcept
+		: has_value{false}
+		, no_init{}
+	{ }
+
+	constexpr expected_storage_base (std::in_place_t)
+		: has_value{true}
+		, empty{}
+	{ }
+
+	template <typename... Args>
+		requires(std::is_constructible_v<E, Args &&...>)
+	constexpr expected_storage_base (unexpect_t, Args &&...args)
+		: has_value{false}
+		, unexpected{std::forward<Args>(args)...}
+	{ }
+
+	expected_storage_base (const expected_storage_base &) = default;
+	expected_storage_base (expected_storage_base &&) = default;
+	expected_storage_base &operator= (const expected_storage_base &) = default;
+	expected_storage_base &operator= (expected_storage_base &&) = default;
+	~expected_storage_base () = default;
+};
+
+//}}}3
+
+// expected_storage<T, E> {{{2
+template <typename T, typename E>
 struct expected_storage: expected_storage_base<T, E>
 {
 	using expected_storage_base<T, E>::expected_storage_base;
 
-	expected_storage (const expected_storage &) = delete;
-	expected_storage (expected_storage &&) = delete;
+
+	template <typename... Args>
+	void value_ctor (Args &&...args)
+		noexcept(std::is_void_v<T> || std::is_nothrow_constructible_v<T, Args...>)
+	{
+		if constexpr (!std::is_void_v<T>)
+		{
+			new(std::addressof(this->value)) T{std::forward<Args>(args)...};
+		}
+		this->has_value = true;
+	}
+
+
+	void value_dtor () noexcept
+	{
+		if constexpr (!std::is_void_v<T>)
+		{
+			this->value.~T();
+		}
+	}
+
+
+	template <typename... Args>
+	void unexpected_ctor (Args &&...args)
+		noexcept(std::is_nothrow_constructible_v<unexpected<E>, std::in_place_t, Args...>)
+	{
+		new(std::addressof(this->unexpected)) unexpected<E>{std::in_place, std::forward<Args>(args)...};
+		this->has_value = false;
+	}
+
+
+	void unexpected_dtor () noexcept
+	{
+		this->unexpected.~unexpected<E>();
+	}
+
+
+	void assign (const expected_storage &that)
+		noexcept
+		(
+			noexcept(assign_value_value(that)) &&
+			noexcept(assign_unexpected_value(that)) &&
+			noexcept(assign_value_unexpected(that)) &&
+			noexcept(assign_unexpected_unexpected(that))
+		)
+	{
+		if (this->has_value && that.has_value)
+		{
+			assign_value_value(that);
+		}
+		else if (!this->has_value && that.has_value)
+		{
+			assign_unexpected_value(that);
+		}
+		else if (this->has_value)
+		{
+			assign_value_unexpected(that);
+		}
+		else
+		{
+			assign_unexpected_unexpected(that);
+		}
+	}
+
+
+	void assign_value_value (const expected_storage &that)
+		noexcept
+		(
+			std::is_void_v<T> ||
+			std::is_nothrow_copy_assignable_v<T>
+		)
+	{
+		if constexpr (!std::is_void_v<T>)
+		{
+			this->value = that.value;
+		}
+	}
+
+
+	void assign_unexpected_value (const expected_storage &that)
+		noexcept
+		(
+			std::is_void_v<T> ||
+			(
+				std::is_nothrow_copy_constructible_v<T> &&
+				std::is_nothrow_move_constructible_v<T>
+			)
+		)
+	{
+		if constexpr (std::is_void_v<T>)
+		{
+			unexpected_dtor();
+			this->has_value = true;
+		}
+		else if constexpr (std::is_nothrow_copy_constructible_v<T>)
+		{
+			unexpected_dtor();
+			value_ctor(that.value);
+		}
+		else if constexpr (std::is_nothrow_move_constructible_v<T>)
+		{
+			auto tmp{that.value};
+			unexpected_dtor();
+			value_ctor(std::move(tmp));
+		}
+		else
+		{
+			auto tmp{this->unexpected.value()};
+			unexpected_dtor();
+			try
+			{
+				value_ctor(that.value);
+			}
+			catch (...)
+			{
+				unexpected_ctor(std::move(tmp));
+				throw;
+			}
+		}
+	}
+
+
+	void assign_value_unexpected (const expected_storage &that)
+		noexcept
+		(
+			std::is_void_v<T> ||
+			(
+				std::is_nothrow_copy_constructible_v<E> &&
+				std::is_nothrow_move_constructible_v<E>
+			)
+		)
+	{
+		if constexpr (std::is_void_v<T>)
+		{
+			unexpected_ctor(that.unexpected.value());
+		}
+		else if constexpr (std::is_nothrow_copy_constructible_v<E>)
+		{
+			value_dtor();
+			unexpected_ctor(that.unexpected.value());
+		}
+		else if constexpr (std::is_nothrow_move_constructible_v<E>)
+		{
+			auto tmp{that.unexpected.value()};
+			value_dtor();
+			unexpected_ctor(std::move(tmp));
+		}
+		else
+		{
+			auto tmp{this->value};
+			value_dtor();
+			try
+			{
+				unexpected_ctor(that.unexpected.value());
+			}
+			catch (...)
+			{
+				value_ctor(std::move(tmp));
+				throw;
+			}
+		}
+	}
+
+
+	void assign_unexpected_unexpected (const expected_storage &that)
+		noexcept(std::is_nothrow_copy_assignable_v<E>)
+	{
+		this->unexpected.value() = that.unexpected.value();
+	}
+
+
+	void assign (expected_storage &&that)
+		noexcept
+		(
+			noexcept(assign_value_value(std::move(that))) &&
+			noexcept(assign_unexpected_value(std::move(that))) &&
+			noexcept(assign_value_unexpected(std::move(that))) &&
+			noexcept(assign_unexpected_unexpected(std::move(that)))
+		)
+	{
+		if (this->has_value && that.has_value)
+		{
+			assign_value_value(std::move(that));
+		}
+		else if (!this->has_value && that.has_value)
+		{
+			assign_unexpected_value(std::move(that));
+		}
+		else if (this->has_value)
+		{
+			assign_value_unexpected(std::move(that));
+		}
+		else
+		{
+			assign_unexpected_unexpected(std::move(that));
+		}
+	}
+
+
+	void assign_value_value (expected_storage &&that)
+		noexcept
+		(
+			std::is_void_v<T> ||
+			std::is_nothrow_move_assignable_v<T>
+		)
+	{
+		if constexpr (!std::is_void_v<T>)
+		{
+			this->value = std::move(that.value);
+		}
+	}
+
+
+	void assign_unexpected_value (expected_storage &&that)
+		noexcept
+		(
+			std::is_void_v<T> ||
+			std::is_nothrow_move_constructible_v<T>
+		)
+	{
+		if constexpr (std::is_void_v<T>)
+		{
+			unexpected_dtor();
+			this->has_value = true;
+		}
+		else if constexpr (std::is_nothrow_move_constructible_v<T>)
+		{
+			unexpected_dtor();
+			value_ctor(std::move(that.value));
+		}
+		else
+		{
+			auto tmp{std::move(this->unexpected.value())};
+			unexpected_dtor();
+			try
+			{
+				value_ctor(std::move(that.value));
+			}
+			catch (...)
+			{
+				unexpected_ctor(std::move(tmp));
+				throw;
+			}
+		}
+	}
+
+
+	void assign_value_unexpected (expected_storage &&that)
+		noexcept
+		(
+			std::is_void_v<T> ||
+			std::is_nothrow_move_constructible_v<E>
+		)
+	{
+		if constexpr (std::is_void_v<T>)
+		{
+			unexpected_ctor(std::move(that.unexpected.value()));
+		}
+		else if constexpr (std::is_nothrow_move_constructible_v<E>)
+		{
+			value_dtor();
+			unexpected_ctor(std::move(that.unexpected.value()));
+		}
+		else
+		{
+			auto tmp{std::move(this->value)};
+			value_dtor();
+			try
+			{
+				unexpected_ctor(std::move(that.unexpected.value()));
+			}
+			catch (...)
+			{
+				value_ctor(std::move(tmp));
+				throw;
+			}
+		}
+	}
+
+
+	void assign_unexpected_unexpected (expected_storage &&that)
+		noexcept(std::is_nothrow_move_assignable_v<E>)
+	{
+		this->unexpected.value() = std::move(that.unexpected.value());
+	}
+};
+
+// expected_copy_ctor {{{2
+template <typename T, typename E>
+constexpr int copy_constructible_v =
+	(std::is_void_v<T> ? trivial_v : 0) +
+	(std::is_copy_constructible_v<T> && std::is_copy_constructible_v<E>) +
+	(std::is_trivially_copy_constructible_v<T> && std::is_trivially_copy_constructible_v<E>)
+;
+
+template <typename T, typename E, int = copy_constructible_v<T, E>>
+struct expected_copy_ctor: expected_storage<T, E>
+{
+	using expected_storage<T, E>::expected_storage;
 };
 
 template <typename T, typename E>
-struct expected_storage<T, E, true, true>: expected_storage_base<T, E>
+struct expected_copy_ctor<T, E, deleted_v>: expected_storage<T, E>
 {
-	using expected_storage_base<T, E>::expected_storage_base;
+	using expected_storage<T, E>::expected_storage;
+	expected_copy_ctor () = default;
+	expected_copy_ctor (expected_copy_ctor &&) = default;
+	expected_copy_ctor &operator= (const expected_copy_ctor &) = default;
+	expected_copy_ctor &operator= (expected_copy_ctor &&) = default;
 
-	expected_storage (const expected_storage &that)
-		: expected_storage{that.has_value}
-	{
-		if (this->has_value)
-		{
-			this->value.construct(that.value);
-		}
-		else
-		{
-			this->unexpected.construct(that.unexpected);
-		}
-	}
-
-	expected_storage (expected_storage &&that)
-		: expected_storage{that.has_value}
-	{
-		if (this->has_value)
-		{
-			this->value.construct(std::move(that.value));
-		}
-		else
-		{
-			this->unexpected.construct(std::move(that.unexpected));
-		}
-	}
+	expected_copy_ctor (const expected_copy_ctor &) = delete;
 };
 
 template <typename T, typename E>
-struct expected_storage<T, E, true, false>: expected_storage_base<T, E>
+struct expected_copy_ctor<T, E, non_trivial_v>: expected_storage<T, E>
 {
-	using expected_storage_base<T, E>::expected_storage_base;
+	using expected_storage<T, E>::expected_storage;
+	expected_copy_ctor () = default;
+	expected_copy_ctor (expected_copy_ctor &&) = default;
+	expected_copy_ctor &operator= (const expected_copy_ctor &) = default;
+	expected_copy_ctor &operator= (expected_copy_ctor &&) = default;
 
-	expected_storage (const expected_storage &that)
-		: expected_storage{that.has_value}
+	expected_copy_ctor (const expected_copy_ctor &that)
+		noexcept
+		(
+			noexcept(this->value_ctor(that.value)) &&
+			noexcept(this->unexpected_ctor(that.unexpected.value()))
+		)
+		: expected_storage<T, E>{no_init}
 	{
-		if (this->has_value)
+		if (that.has_value)
 		{
-			this->value.construct(that.value);
+			this->value_ctor(that.value);
 		}
 		else
 		{
-			this->unexpected.construct(that.unexpected);
+			this->unexpected_ctor(that.unexpected.value());
 		}
 	}
+};
 
-	expected_storage (expected_storage &&) = delete;
+// expected_move_ctor {{{2
+template <typename T, typename E>
+constexpr int move_constructible_v =
+	(std::is_void_v<T> ? trivial_v : 0) +
+	(std::is_move_constructible_v<T> && std::is_move_constructible_v<E>) +
+	(std::is_trivially_move_constructible_v<T> && std::is_trivially_move_constructible_v<E>)
+;
+
+template <typename T, typename E, int = move_constructible_v<T, E>>
+struct expected_move_ctor: expected_copy_ctor<T, E>
+{
+	using expected_copy_ctor<T, E>::expected_copy_ctor;
 };
 
 template <typename T, typename E>
-struct expected_storage<T, E, false, true>: expected_storage_base<T, E>
+struct expected_move_ctor<T, E, deleted_v>: expected_copy_ctor<T, E>
 {
-	using expected_storage_base<T, E>::expected_storage_base;
+	using expected_copy_ctor<T, E>::expected_copy_ctor;
+	expected_move_ctor () = default;
+	expected_move_ctor (const expected_move_ctor &) = default;
+	expected_move_ctor &operator= (const expected_move_ctor &) = default;
+	expected_move_ctor &operator= (expected_move_ctor &&) = default;
 
-	expected_storage (const expected_storage &that) = delete;
+	expected_move_ctor (expected_move_ctor &&) = delete;
+};
 
-	expected_storage (expected_storage &&that)
-		: expected_storage{that.has_value}
+template <typename T, typename E>
+struct expected_move_ctor<T, E, non_trivial_v>: expected_copy_ctor<T, E>
+{
+	using expected_copy_ctor<T, E>::expected_copy_ctor;
+	expected_move_ctor () = default;
+	expected_move_ctor (const expected_move_ctor &) = default;
+	expected_move_ctor &operator= (const expected_move_ctor &) = default;
+	expected_move_ctor &operator= (expected_move_ctor &&) = default;
+
+	expected_move_ctor (expected_move_ctor &&that)
+		noexcept
+		(
+			noexcept(this->value_ctor(std::move(that.value))) &&
+			noexcept(this->unexpected_ctor(std::move(that.unexpected.value())))
+		)
+		: expected_copy_ctor<T, E>{no_init}
 	{
-		if (this->has_value)
+		if (that.has_value)
 		{
-			this->value.construct(std::move(that.value));
+			this->value_ctor(std::move(that.value));
 		}
 		else
 		{
-			this->unexpected.construct(std::move(that.unexpected));
+			this->unexpected_ctor(std::move(that.unexpected.value()));
 		}
 	}
 };
+
+// expected_copy_assign {{{2
+template <typename T, typename E>
+constexpr int copy_assignable_v =
+	(std::is_void_v<T> ? trivial_v : 0) +
+	(std::is_copy_assignable_v<T> && std::is_copy_assignable_v<E>) +
+	(std::is_trivially_copy_assignable_v<T> && std::is_trivially_copy_assignable_v<E>)
+;
+
+template <typename T, typename E, int = copy_assignable_v<T, E>>
+struct expected_copy_assign: expected_move_ctor<T, E>
+{
+	using expected_move_ctor<T, E>::expected_move_ctor;
+};
+
+template <typename T, typename E>
+struct expected_copy_assign<T, E, deleted_v>: expected_move_ctor<T, E>
+{
+	using expected_move_ctor<T, E>::expected_move_ctor;
+	expected_copy_assign () = default;
+	expected_copy_assign (const expected_copy_assign &) = default;
+	expected_copy_assign (expected_copy_assign &&) = default;
+	expected_copy_assign &operator= (expected_copy_assign &&) = default;
+
+	expected_copy_assign &operator= (const expected_copy_assign &) = delete;
+};
+
+template <typename T, typename E>
+struct expected_copy_assign<T, E, non_trivial_v>: expected_move_ctor<T, E>
+{
+	using expected_move_ctor<T, E>::expected_move_ctor;
+	expected_copy_assign () = default;
+	expected_copy_assign (const expected_copy_assign &) = default;
+	expected_copy_assign (expected_copy_assign &&) = default;
+	expected_copy_assign &operator= (expected_copy_assign &&) = default;
+
+	expected_copy_assign &operator= (const expected_copy_assign &that)
+		noexcept(noexcept(this->assign(that)))
+	{
+		this->assign(that);
+		return *this;
+	}
+};
+
+// expected_move_assign {{{2
+template <typename T, typename E>
+constexpr int move_assignable_v =
+	(std::is_void_v<T> ? trivial_v : 0) +
+	(std::is_move_assignable_v<T> && std::is_move_assignable_v<E>) +
+	(std::is_trivially_move_assignable_v<T> && std::is_trivially_move_assignable_v<E>)
+;
+
+template <typename T, typename E, int = move_assignable_v<T, E>>
+struct expected_move_assign: expected_copy_assign<T, E>
+{
+	using expected_copy_assign<T, E>::expected_copy_assign;
+};
+
+template <typename T, typename E>
+struct expected_move_assign<T, E, deleted_v>: expected_copy_assign<T, E>
+{
+	using expected_copy_assign<T, E>::expected_copy_assign;
+	expected_move_assign () = default;
+	expected_move_assign (const expected_move_assign &) = default;
+	expected_move_assign (expected_move_assign &&) = default;
+	expected_move_assign &operator= (const expected_move_assign &) = default;
+
+	expected_move_assign &operator= (expected_move_assign &&) = delete;
+};
+
+template <typename T, typename E>
+struct expected_move_assign<T, E, non_trivial_v>: expected_copy_assign<T, E>
+{
+	using expected_copy_assign<T, E>::expected_copy_assign;
+	expected_move_assign () = default;
+	expected_move_assign (const expected_move_assign &) = default;
+	expected_move_assign (expected_move_assign &&) = default;
+	expected_move_assign &operator= (const expected_move_assign &) = default;
+
+	expected_move_assign &operator= (expected_move_assign &&that)
+		noexcept(noexcept(this->assign(std::move(that))))
+	{
+		this->assign(std::move(that));
+		return *this;
+	}
+};
+
+// }}}2
+
+template <typename T, typename E>
+using expected_impl = expected_move_assign<T, E>;
+
+template <typename T, typename E, typename U, typename G, typename UR, typename GR>
+static constexpr bool expected_converts_from_v =
+	((std::is_void_v<T> && std::is_void_v<U>) || std::is_constructible_v<T, UR>) &&
+	std::is_constructible_v<E, GR> &&
+
+	!std::is_constructible_v<T, const expected<U, G> &>  &&
+	!std::is_constructible_v<T,       expected<U, G> &>  &&
+	!std::is_constructible_v<T, const expected<U, G> &&> &&
+	!std::is_constructible_v<T,       expected<U, G> &&> &&
+
+	!std::is_convertible_v<const expected<U, G> &,  T>   &&
+	!std::is_convertible_v<      expected<U, G> &,  T>   &&
+	!std::is_convertible_v<const expected<U, G> &&, T>   &&
+	!std::is_convertible_v<      expected<U, G> &&, T>   &&
+
+	!std::is_constructible_v<unexpected<E>, const expected<U, G> &>  &&
+	!std::is_constructible_v<unexpected<E>,       expected<U, G> &>  &&
+	!std::is_constructible_v<unexpected<E>, const expected<U, G> &&> &&
+	!std::is_constructible_v<unexpected<E>,       expected<U, G> &&> &&
+
+	!std::is_convertible_v<const expected<U, G> &,  unexpected<E>>   &&
+	!std::is_convertible_v<      expected<U, G> &,  unexpected<E>>   &&
+	!std::is_convertible_v<const expected<U, G> &&, unexpected<E>>   &&
+	!std::is_convertible_v<      expected<U, G> &&, unexpected<E>>
+;
 
 template <typename T, typename E>
 static constexpr bool expected_is_swappable_v =
@@ -418,39 +1135,17 @@ static constexpr bool expected_is_nothrow_swappable_v<void, E> =
 	std::is_nothrow_swappable_v<E>
 ;
 
+
 } // namespace __bits
 
 
 // expected<T, E> {{{1
-
 template <typename T, typename E>
-class expected
+class expected: private __bits::expected_impl<T, E>
 {
 private:
 
-	template <typename U, typename G>
-	static constexpr bool converts_from_expected_v =
-		//
-		std::is_constructible_v<T, const expected<U, G> &> ||
-		std::is_constructible_v<T,       expected<U, G> &> ||
-		std::is_constructible_v<T, const expected<U, G> &&> ||
-		std::is_constructible_v<T,       expected<U, G> &&> ||
-		//
-		std::is_convertible_v<const expected<U, G> &,  T> ||
-		std::is_convertible_v<      expected<U, G> &,  T> ||
-		std::is_convertible_v<const expected<U, G> &&, T> ||
-		std::is_convertible_v<      expected<U, G> &&, T> ||
-		//
-		std::is_constructible_v<unexpected<E>, const expected<U, G> &> ||
-		std::is_constructible_v<unexpected<E>,       expected<U, G> &> ||
-		std::is_constructible_v<unexpected<E>, const expected<U, G> &&> ||
-		std::is_constructible_v<unexpected<E>,       expected<U, G> &&> ||
-		//
-		std::is_convertible_v<const expected<U, G> &,  unexpected<E>> ||
-		std::is_convertible_v<      expected<U, G> &,  unexpected<E>> ||
-		std::is_convertible_v<const expected<U, G> &&, unexpected<E>> ||
-		std::is_convertible_v<      expected<U, G> &&, unexpected<E>>
-	;
+	using impl = __bits::expected_impl<T, E>;
 
 public:
 
@@ -466,45 +1161,51 @@ public:
 	template <typename U>
 	using rebind = expected<U, error_type>;
 
-
-	//
-	// Constructors
-	//
-
-	template <typename U = T>
-		requires(std::is_default_constructible_v<U> || std::is_void_v<U>)
-	constexpr expected ()
-		: impl_{true}
-	{
-		if constexpr (!std::is_void_v<U>)
-		{
-			impl_.value.construct();
-		}
-	}
-
-
+	constexpr expected () = default;
 	constexpr expected (const expected &) = default;
 	constexpr expected (expected &&) = default;
+	expected &operator= (const expected &) = default;
+	expected &operator= (expected &&) = default;
 
+
+	// Constructors {{{2
 
 	template <typename U, typename G>
 		requires
 		(
-			std::is_constructible_v<T, const U &> &&
-			std::is_constructible_v<E, const G &> &&
-			!converts_from_expected_v<U, G>
+			__bits::expected_converts_from_v<
+				T, E, U, G,
+				std::add_lvalue_reference_t<const U>,
+				const G &
+			>
 		)
-	explicit(!std::is_convertible_v<const U &, T> || !std::is_convertible_v<const G &, E>)
+		explicit
+		(
+			(
+				std::is_void_v<T> &&
+				std::is_void_v<U> &&
+				!std::is_convertible_v<std::add_lvalue_reference_t<const U>, T>
+			)
+			||
+			!std::is_convertible_v<const G &, E>
+		)
 	constexpr expected (const expected<U, G> &that)
-		: impl_{that.has_value()}
+		: impl{__bits::no_init}
 	{
-		if (impl_.has_value)
+		if (that)
 		{
-			impl_.value.construct(*that);
+			if constexpr (std::is_void_v<U>)
+			{
+				impl::value_ctor();
+			}
+			else
+			{
+				impl::value_ctor(*that);
+			}
 		}
 		else
 		{
-			impl_.unexpected.construct(that.error());
+			impl::unexpected_ctor(that.error());
 		}
 	}
 
@@ -512,21 +1213,39 @@ public:
 	template <typename U, typename G>
 		requires
 		(
-			std::is_constructible_v<T, U &&> &&
-			std::is_constructible_v<E, G &&> &&
-			!converts_from_expected_v<U, G>
+			__bits::expected_converts_from_v<
+				T, E, U, G,
+				std::add_rvalue_reference_t<U>,
+				G &&
+			>
 		)
-	explicit(!std::is_convertible_v<U &&, T> || !std::is_convertible_v<G &&, E>)
+		explicit
+		(
+			(
+				std::is_void_v<T> &&
+				std::is_void_v<U> &&
+				!std::is_convertible_v<std::add_rvalue_reference_t<U>, T>
+			)
+			||
+			!std::is_convertible_v<G &&, E>
+		)
 	constexpr expected (expected<U, G> &&that)
-		: impl_{that.has_value()}
+		: impl{__bits::no_init}
 	{
-		if (impl_.has_value)
+		if (that)
 		{
-			impl_.value.construct(std::move(*that));
+			if constexpr (std::is_void_v<U>)
+			{
+				impl::value_ctor();
+			}
+			else
+			{
+				impl::value_ctor(std::move(*that));
+			}
 		}
 		else
 		{
-			impl_.unexpected.construct(std::move(that.error()));
+			impl::unexpected_ctor(std::move(that.error()));
 		}
 	}
 
@@ -542,20 +1261,17 @@ public:
 		)
 	explicit(!std::is_convertible_v<U &&, T>)
 	constexpr expected (U &&v)
-		: impl_{true}
-	{
-		impl_.value.construct(std::forward<U>(v));
-	}
+		: impl{std::in_place, std::forward<U>(v)}
+	{ }
 
 
 	template <typename G = E>
 		requires(std::is_constructible_v<E, const G &>)
 	explicit(!std::is_convertible_v<const G &, E>)
 	constexpr expected (const unexpected<G> &e)
-		: impl_{false}
-	{
-		impl_.unexpected.construct(e.value());
-	}
+		noexcept(std::is_nothrow_constructible_v<E, const G &>)
+		: impl{unexpect, e.value()}
+	{ }
 
 
 	template <typename G = E>
@@ -563,10 +1279,8 @@ public:
 	explicit(!std::is_convertible_v<G &&, E>)
 	constexpr expected (unexpected<G> &&e)
 		noexcept(std::is_nothrow_constructible_v<E, G &&>)
-		: impl_{false}
-	{
-		impl_.unexpected.construct(std::move(e.value()));
-	}
+		: impl{unexpect, std::move(e.value())}
+	{ }
 
 
 	template <typename... Args>
@@ -575,219 +1289,21 @@ public:
 			(std::is_void_v<T> && sizeof...(Args) == 0) ||
 			(!std::is_void_v<T> && std::is_constructible_v<T, Args...>)
 		)
-	explicit constexpr expected (std::in_place_t, Args &&...args)
-		: impl_{true}
-	{
-		if constexpr (!std::is_void_v<T>)
-		{
-			impl_.value.construct(std::forward<Args>(args)...);
-		}
-	}
+	explicit constexpr expected (std::in_place_t tag, Args &&...args)
+		noexcept(std::is_nothrow_constructible_v<T, Args...>)
+		: impl{tag, std::forward<Args>(args)...}
+	{ }
 
 
 	template <typename... Args>
 		requires(std::is_constructible_v<E, Args...>)
-	explicit expected (unexpect_t, Args &&...args)
+	explicit constexpr expected (unexpect_t tag, Args &&...args)
 		noexcept(std::is_nothrow_constructible_v<E, Args...>)
-		: impl_{false}
-	{
-		impl_.unexpected.construct(std::forward<Args>(args)...);
-	}
+		: impl{tag, std::forward<Args>(args)...}
+	{ }
 
 
-	//
-	// Destructor
-	//
-
-	~expected ()
-	{
-		if (impl_.has_value)
-		{
-			if constexpr (!std::is_void_v<T> && !std::is_trivially_destructible_v<T>)
-			{
-				impl_.value.destruct();
-			}
-		}
-		else
-		{
-			if constexpr (!std::is_trivially_destructible_v<E>)
-			{
-				impl_.unexpected.destruct();
-			}
-		}
-	}
-
-
-	//
-	// Assignment
-	//
-
-	expected &operator= (const expected &that)
-		noexcept
-		(
-			std::is_nothrow_copy_constructible_v<T> &&
-			std::is_nothrow_copy_assignable_v<T> &&
-			std::is_nothrow_move_constructible_v<T> &&
-			std::is_nothrow_copy_constructible_v<E>
-		)
-	{
-		if (impl_.has_value && that.impl_.has_value)
-		{
-			if constexpr (!std::is_void_v<T>)
-			{
-				*impl_.value = *that.impl_.value;
-			}
-		}
-		else if (!impl_.has_value && that.impl_.has_value)
-		{
-			if constexpr (std::is_void_v<T>)
-			{
-				impl_.unexpected.destruct();
-			}
-			else if constexpr (std::is_nothrow_copy_constructible_v<T>)
-			{
-				impl_.unexpected.destruct();
-				impl_.value.construct(*that.impl_.value);
-			}
-			else if constexpr (std::is_nothrow_move_constructible_v<T>)
-			{
-				auto tmp{*that.impl_.value};
-				impl_.unexpected.destruct();
-				impl_.value.construct(std::move(tmp));
-			}
-			else
-			{
-				auto tmp{*impl_.unexpected};
-				impl_.unexpected.destruct();
-				try
-				{
-					impl_.value.construct(*that.impl_.value);
-				}
-				catch (...)
-				{
-					impl_.unexpected.construct(std::move(tmp));
-					throw;
-				}
-			}
-			impl_.has_value = true;
-		}
-		else if (impl_.has_value)
-		{
-			if constexpr (std::is_void_v<T>)
-			{
-				impl_.unexpected.construct(*that.impl_.unexpected);
-			}
-			else if constexpr (std::is_nothrow_copy_constructible_v<E>)
-			{
-				impl_.value.destruct();
-				impl_.unexpected.construct(*that.impl_.unexpected);
-			}
-			else if constexpr (std::is_nothrow_move_constructible_v<E>)
-			{
-				auto tmp{*that.impl_.unexpected};
-				impl_.value.destruct();
-				impl_.unexpected.construct(std::move(tmp));
-			}
-			else
-			{
-				auto tmp{*impl_.value};
-				impl_.value.destruct();
-				try
-				{
-					impl_.unexpected.construct(*that.impl_.unexpected);
-				}
-				catch (...)
-				{
-					impl_.value.construct(std::move(tmp));
-					throw;
-				}
-			}
-			impl_.has_value = false;
-		}
-		else
-		{
-			*impl_.unexpected = *that.impl_.unexpected;
-		}
-		return *this;
-	}
-
-
-	expected &operator= (expected &&that)
-		noexcept
-		(
-			std::is_nothrow_move_constructible_v<T> &&
-			std::is_nothrow_move_assignable_v<T> &&
-			std::is_nothrow_move_constructible_v<E>
-		)
-	{
-		if (impl_.has_value && that.impl_.has_value)
-		{
-			if constexpr (!std::is_void_v<T>)
-			{
-				*impl_.value = std::move(*that.impl_.value);
-			}
-		}
-		else if (!impl_.has_value && that.impl_.has_value)
-		{
-			if constexpr (std::is_void_v<T>)
-			{
-				impl_.unexpected.destruct();
-			}
-			else if constexpr (std::is_nothrow_move_constructible_v<T>)
-			{
-				impl_.unexpected.destruct();
-				impl_.value.construct(std::move(*that.impl_.value));
-			}
-			else
-			{
-				auto tmp{std::move(*impl_.unexpected)};
-				impl_.unexpected.destruct();
-				try
-				{
-					impl_.value.construct(std::move(*that.impl_.value));
-				}
-				catch (...)
-				{
-					impl_.unexpected.construct(std::move(tmp));
-					throw;
-				}
-			}
-			impl_.has_value = true;
-		}
-		else if (impl_.has_value)
-		{
-			if constexpr (std::is_void_v<T>)
-			{
-				impl_.unexpected.construct(std::move(*that.impl_.unexpected));
-			}
-			else if constexpr (std::is_nothrow_move_constructible_v<E>)
-			{
-				impl_.value.destruct();
-				impl_.unexpected.construct(std::move(*that.impl_.unexpected));
-			}
-			else
-			{
-				auto tmp{std::move(*impl_.value)};
-				impl_.value.destruct();
-				try
-				{
-					impl_.unexpected.construct(std::move(*that.impl_.unexpected));
-				}
-				catch (...)
-				{
-					impl_.value.construct(std::move(tmp));
-					throw;
-				}
-			}
-			impl_.has_value = false;
-		}
-		else
-		{
-			*impl_.unexpected = std::move(*that.impl_.unexpected);
-		}
-		return *this;
-	}
-
+	// Assignment {{{2
 
 	template <typename G = E>
 		requires
@@ -797,18 +1313,14 @@ public:
 		)
 	expected &operator= (const unexpected<G> &e)
 	{
-		if (impl_.has_value)
+		if (impl::has_value)
 		{
-			if constexpr (!std::is_void_v<T>)
-			{
-				impl_.value.destruct();
-			}
-			impl_.unexpected.construct(e);
-			impl_.has_value = false;
+			impl::value_dtor();
+			impl::unexpected_ctor(e.value());
 		}
 		else
 		{
-			*impl_.unexpected = e;
+			impl::unexpected.value() = e.value();
 		}
 		return *this;
 	}
@@ -822,18 +1334,14 @@ public:
 		)
 	expected &operator= (unexpected<G> &&e)
 	{
-		if (impl_.has_value)
+		if (impl::has_value)
 		{
-			if constexpr (!std::is_void_v<T>)
-			{
-				impl_.value.destruct();
-			}
-			impl_.unexpected.construct(std::move(e));
-			impl_.has_value = false;
+			impl::value_dtor();
+			impl::unexpected_ctor(std::move(e.value()));
 		}
 		else
 		{
-			*impl_.unexpected = std::move(e);
+			impl::unexpected.value() = std::move(e.value());
 		}
 		return *this;
 	}
@@ -851,33 +1359,31 @@ public:
 		)
 	expected &operator= (U &&v)
 	{
-		if (impl_.has_value)
+		if (impl::has_value)
 		{
-			*impl_.value = std::forward<U>(v);
+			impl::value = std::forward<U>(v);
 		}
 		else
 		{
 			if constexpr (std::is_nothrow_constructible_v<T, U>)
 			{
-				impl_.unexpected.destruct();
-				impl_.value.construct(std::forward<U>(v));
+				impl::unexpected_dtor();
+				impl::value_ctor(std::forward<U>(v));
 			}
 			else
 			{
-				auto tmp{std::move(*impl_.unexpected)};
-				impl_.unexpected.destruct();
-
+				auto tmp{std::move(impl::unexpected.value())};
+				impl::unexpected_dtor();
 				try
 				{
-					impl_.value.construct(std::forward<U>(v));
+					impl::value_ctor(std::forward<U>(v));
 				}
 				catch (...)
 				{
-					impl_.unexpected.construct(std::move(tmp));
+					impl::unexpected_ctor(std::move(tmp));
 					throw;
 				}
 			}
-			impl_.has_value = true;
 		}
 		return *this;
 	}
@@ -887,162 +1393,90 @@ public:
 		requires(std::is_void_v<U>)
 	void emplace ()
 	{
-		if (!impl_.has_value)
+		if (!impl::has_value)
 		{
-			impl_.unexpected.destruct();
-			impl_.has_value = true;
+			impl::unexpected_dtor();
+			impl::value_ctor();
 		}
 	}
 
 
 	template <typename U = T, typename... Args>
-		requires(!std::is_void_v<U> && std::is_nothrow_constructible_v<T, Args...>)
+		requires
+		(
+			!std::is_void_v<T> &&
+			std::is_constructible_v<T, Args &&...>
+		)
 	U &emplace (Args &&...args)
 	{
-		if (impl_.has_value)
+		if (impl::has_value)
 		{
-			impl_.value.destruct();
-			impl_.value.construct(std::forward<Args>(args)...);
+			impl::value_dtor();
+			impl::value_ctor(std::forward<Args>(args)...);
 		}
 		else
 		{
 			if constexpr (std::is_nothrow_constructible_v<T, Args...>)
 			{
-				impl_.unexpected.destruct();
-				impl_.value.construct(std::forward<Args>(args)...);
+				impl::unexpected_dtor();
+				impl::value_ctor(std::forward<Args>(args)...);
 			}
 			else if constexpr (std::is_nothrow_move_constructible_v<T>)
 			{
 				T tmp{std::forward<Args>(args)...};
-				impl_.unexpected.destruct();
-				impl_.value.construct(std::move(tmp));
+				impl::unexpected_dtor();
+				impl::value_ctor(std::move(tmp));
 			}
 			else
 			{
-				auto tmp{std::move(*impl_.unexpected)};
-				impl_.unexpected.destruct();
-
+				auto tmp{std::move(impl::unexpected.value())};
+				impl::unexpected_dtor();
 				try
 				{
-					impl_.value.construct(std::forward<Args>(args)...);
+					impl::value_ctor(std::forward<Args>(args)...);
 				}
 				catch (...)
 				{
-					impl_.unexpected.construct(std::move(tmp));
+					impl::unexpected_ctor(std::move(tmp));
 					throw;
 				}
 			}
-			impl_.has_value = true;
 		}
 		return **this;
 	}
 
 
-	//
-	// Swap
-	//
+	// Swap {{{2
 
 	template <typename U = T, typename G = E>
 		requires(__bits::expected_is_swappable_v<U, G>)
 	void swap (expected &that)
 		noexcept(__bits::expected_is_nothrow_swappable_v<U, G>)
 	{
-		using std::swap;
-		if (impl_.has_value && that.impl_.has_value)
+		if (impl::has_value && that.impl::has_value)
 		{
-			if constexpr (!std::is_void_v<U>)
-			{
-				swap(*impl_.value, *that.impl_.value);
-			}
+			swap_value_value(that);
 		}
-		else if (!impl_.has_value && that.impl_.has_value)
+		else if (!impl::has_value && that.impl::has_value)
 		{
-			that.swap(*this);
+			swap_unexpected_value(that);
 		}
-		else if (impl_.has_value)
+		else if (impl::has_value)
 		{
-			if constexpr (std::is_void_v<U>)
-			{
-				impl_.unexpected.construct(std::move(*that.impl_.unexpected));
-				impl_.has_value = false;
-				that.impl_.unexpected.destruct();
-				that.impl_.has_value = true;
-			}
-			else if constexpr (std::is_nothrow_move_constructible_v<U> &&
-				std::is_nothrow_move_constructible_v<G>)
-			{
-				auto tmp{std::move(*that.impl_.unexpected)};
-
-				that.impl_.unexpected.destruct();
-				that.impl_.value.construct(std::move(*impl_.value));
-				that.impl_.has_value = true;
-
-				impl_.value.destruct();
-				impl_.unexpected.construct(std::move(tmp));
-				impl_.has_value = false;
-			}
-			else if constexpr (std::is_nothrow_move_constructible_v<G>)
-			{
-				auto tmp{std::move(*that.impl_.unexpected)};
-				that.impl_.unexpected.destruct();
-
-				try
-				{
-					that.impl_.value.construct(std::move(*impl_.value));
-					that.impl_.has_value = true;
-				}
-				catch (...)
-				{
-					that.impl_.unexpected.construct(std::move(tmp));
-					throw;
-				}
-
-				impl_.value.destruct();
-				impl_.unexpected.construct(std::move(tmp));
-				impl_.has_value = false;
-			}
-			else if constexpr (std::is_nothrow_move_constructible_v<U>)
-			{
-				auto tmp{std::move(*impl_.value)};
-				impl_.value.destruct();
-
-				try
-				{
-					impl_.unexpected.construct(std::move(*that.impl_.unexpected));
-					impl_.has_value = false;
-				}
-				catch (...)
-				{
-					impl_.value.construct(std::move(tmp));
-					throw;
-				}
-
-				that.impl_.unexpected.destruct();
-				that.impl_.value.construct(std::move(tmp));
-				that.impl_.has_value = true;
-			}
-			else
-			{
-				static_assert(
-					std::is_nothrow_move_constructible_v<U> || std::is_nothrow_move_constructible_v<G>,
-					"function is undefined"
-				);
-			}
+			swap_value_unexpected(that);
 		}
 		else
 		{
-			swap(*impl_.unexpected, *that.impl_.unexpected);
+			swap_unexpected_unexpected(that);
 		}
 	}
 
 
-	//
-	// Observers
-	//
+	// Observers {{{2
 
 	constexpr bool has_value () const noexcept
 	{
-		return impl_.has_value;
+		return impl::has_value;
 	}
 
 
@@ -1056,7 +1490,7 @@ public:
 		requires(!std::is_void_v<U>)
 	constexpr const U *operator-> () const noexcept
 	{
-		return impl_.value.operator->();
+		return std::addressof(impl::value);
 	}
 
 
@@ -1064,7 +1498,7 @@ public:
 		requires(!std::is_void_v<U>)
 	constexpr U *operator-> () noexcept
 	{
-		return impl_.value.operator->();
+		return std::addressof(impl::value);
 	}
 
 
@@ -1072,7 +1506,7 @@ public:
 		requires(!std::is_void_v<U>)
 	constexpr const U &operator* () const &
 	{
-		return impl_.value.operator*();
+		return impl::value;
 	}
 
 
@@ -1080,7 +1514,7 @@ public:
 		requires(!std::is_void_v<U>)
 	constexpr U &operator* () &
 	{
-		return impl_.value.operator*();
+		return impl::value;
 	}
 
 
@@ -1088,7 +1522,7 @@ public:
 		requires(!std::is_void_v<U>)
 	constexpr const U &&operator* () const &&
 	{
-		return std::move(impl_.value.operator*());
+		return std::move(impl::value);
 	}
 
 
@@ -1096,31 +1530,31 @@ public:
 		requires(!std::is_void_v<U>)
 	constexpr U &&operator* () &&
 	{
-		return std::move(impl_.value.operator*());
+		return std::move(impl::value);
 	}
 
 
 	constexpr const E &error () const &
 	{
-		return impl_.unexpected->value();
+		return impl::unexpected.value();
 	}
 
 
 	constexpr E &error () &
 	{
-		return impl_.unexpected->value();
+		return impl::unexpected.value();
 	}
 
 
 	constexpr const E &&error () const &&
 	{
-		return std::move(impl_.unexpected->value());
+		return std::move(impl::unexpected.value());
 	}
 
 
 	constexpr E &&error () &&
 	{
-		return std::move(impl_.unexpected->value());
+		return std::move(impl::unexpected.value());
 	}
 
 
@@ -1128,7 +1562,7 @@ public:
 		requires(!std::is_void_v<U>)
 	constexpr const U &value () const &
 	{
-		return require_value(), impl_.value.get();
+		return require_value(), impl::value;
 	}
 
 
@@ -1136,7 +1570,7 @@ public:
 		requires(!std::is_void_v<U>)
 	constexpr U &value () &
 	{
-		return require_value(), impl_.value.get();
+		return require_value(), impl::value;
 	}
 
 
@@ -1144,7 +1578,7 @@ public:
 		requires(!std::is_void_v<U>)
 	constexpr const U &&value () const &&
 	{
-		return require_value(), std::move(impl_.value.get());
+		return require_value(), std::move(impl::value);
 	}
 
 
@@ -1152,45 +1586,204 @@ public:
 		requires(!std::is_void_v<U>)
 	constexpr U &&value () &&
 	{
-		return require_value(), std::move(impl_.value.get());
+		return require_value(), std::move(impl::value);
 	}
 
 
 	template <typename U>
-		requires(std::is_copy_constructible_v<T> && std::is_convertible_v<U&&, T>)
+		requires(std::is_copy_constructible_v<T> && std::is_convertible_v<U, T>)
 	constexpr T value_or (U &&v) const &
 	{
-		return impl_.has_value
-			? impl_.value.get()
-			: static_cast<T>(std::forward<U>(v))
-		;
+		return impl::has_value ? impl::value : static_cast<T>(std::forward<U>(v));
 	}
 
 
 	template <typename U>
-		requires(std::is_move_constructible_v<T> && std::is_convertible_v<U&&, T>)
+		requires(std::is_move_constructible_v<T> && std::is_convertible_v<U, T>)
 	constexpr T value_or (U &&v) &&
 	{
-		return impl_.has_value
-			? std::move(impl_.value.get())
-			: static_cast<T>(std::forward<U>(v))
-		;
+		return impl::has_value ? std::move(impl::value) : static_cast<T>(std::forward<U>(v));
 	}
+
+	//}}}2
 
 
 private:
 
-	__bits::expected_storage<T, unexpected_type> impl_{};
-
-	constexpr bool require_value () const &
+	constexpr bool require_value () const
 	{
-		if (!impl_.has_value)
+		if (!impl::has_value)
 		{
 			throw bad_expected_access<E>(error());
 		}
-		return impl_.has_value;
+		return true;
+	}
+
+	void swap_value_value (expected &that)
+	{
+		if constexpr (!std::is_void_v<T>)
+		{
+			using std::swap;
+			swap(impl::value, that.impl::value);
+		}
+	}
+
+	void swap_unexpected_unexpected (expected &that)
+	{
+		using std::swap;
+		swap(impl::unexpected.value(), that.impl::unexpected.value());
+	}
+
+	void swap_unexpected_value (expected &that)
+	{
+		that.swap(*this);
+	}
+
+	void swap_value_unexpected (expected &that)
+	{
+		if constexpr (std::is_void_v<T>)
+		{
+			impl::unexpected_ctor(std::move(that.impl::unexpected.value()));
+			that.impl::unexpected_dtor();
+			that.impl::value_ctor();
+		}
+		else if constexpr (
+			std::is_nothrow_move_constructible_v<T> &&
+			std::is_nothrow_move_constructible_v<E>)
+		{
+			auto tmp{std::move(that.impl::unexpected.value())};
+			that.impl::unexpected_dtor();
+			that.impl::value_ctor(std::move(impl::value));
+			impl::value_dtor();
+			impl::unexpected_ctor(std::move(tmp));
+		}
+		else if constexpr (std::is_nothrow_move_constructible_v<E>)
+		{
+			auto tmp{std::move(that.impl::unexpected.value())};
+			that.impl::unexpected_dtor();
+			try
+			{
+				that.impl::value_ctor(std::move(impl::value));
+			}
+			catch (...)
+			{
+				that.impl::unexpected_ctor(std::move(tmp));
+				throw;
+			}
+			impl::value_dtor();
+			impl::unexpected_ctor(std::move(tmp));
+		}
+		else if constexpr (std::is_nothrow_move_constructible_v<T>)
+		{
+			auto tmp{std::move(impl::value)};
+			impl::value_dtor();
+			try
+			{
+				impl::unexpected_ctor(std::move(that.impl::unexpected.value()));
+			}
+			catch (...)
+			{
+				impl::value_ctor(std::move(tmp));
+				throw;
+			}
+			that.impl::unexpected_dtor();
+			that.impl::value_ctor(std::move(tmp));
+		}
+		else
+		{
+			static_assert
+			(
+				std::is_nothrow_move_constructible_v<T> ||
+				std::is_nothrow_move_constructible_v<E>
+			);
+		}
 	}
 };
+
+
+template <typename T, typename E, typename U, typename G>
+constexpr bool operator== (const expected<T, E> &l, const expected<U, G> &r)
+{
+	if (l.has_value() && r.has_value())
+	{
+		if constexpr (std::is_void_v<T> && std::is_void_v<U>)
+		{
+			return true;
+		}
+		else
+		{
+			return *l == *r;
+		}
+	}
+	else if (!l.has_value() && !r.has_value())
+	{
+		return l.error() == r.error();
+	}
+	return false;
+}
+
+
+template <typename T, typename E, typename U, typename G>
+constexpr bool operator!= (const expected<T, E> &l, const expected<U, G> &r)
+{
+	return !(l == r);
+}
+
+
+template <typename T, typename E, typename U>
+constexpr bool operator== (const expected<T, E> &l, const U &r)
+{
+	return l.has_value() && *l == r;
+}
+
+
+template <typename T, typename E, typename U>
+constexpr bool operator== (const U &l, const expected<T, E> &r)
+{
+	return r == l;
+}
+
+
+template <typename T, typename E, typename U>
+constexpr bool operator!= (const expected<T, E> &l, const U &r)
+{
+	return !(l == r);
+}
+
+
+template <typename T, typename E, typename U>
+constexpr bool operator!= (const U &l, const expected<T, E> &r)
+{
+	return r != l;
+}
+
+
+template <typename T, typename E, typename G>
+constexpr bool operator== (const expected<T, E> &l, const unexpected<G> &r)
+{
+	return !l.has_value() && l.error() == r.value();
+}
+
+
+template <typename T, typename E, typename G>
+constexpr bool operator== (const unexpected<G> &l, const expected<T, E> &r)
+{
+	return r == l;
+}
+
+
+template <typename T, typename E, typename G>
+constexpr bool operator!= (const expected<T, E> &l, const unexpected<G> &r)
+{
+	return l.has_value() || l.error() != r.value();
+}
+
+
+template <typename T, typename E, typename G>
+constexpr bool operator!= (const unexpected<G> &l, const expected<T, E> &r)
+{
+	return r != l;
+}
 
 
 template <typename T, typename E>

--- a/pal/expected.test.cpp
+++ b/pal/expected.test.cpp
@@ -1389,28 +1389,66 @@ TEMPLATE_TEST_CASE("expected", "",
 
 	SECTION("expected(const expected &)")
 	{
-		TestType x{v1}, y{x};
-		CHECK(y.value() == v1);
+		SECTION("x")
+		{
+			TestType x{v1}, y{x};
+			CHECK(y.value() == v1);
+		}
+
+		SECTION("!x")
+		{
+			TestType x{pal::unexpect, e1}, y{x};
+			CHECK(y.error() == e1);
+		}
 	}
 
 	SECTION("expected(expected &&)")
 	{
-		TestType x, y{std::move(x)};
-		CHECK(y.value() == T{});
+		SECTION("x")
+		{
+			TestType x, y{std::move(x)};
+			CHECK(y.value() == T{});
+		}
+
+		SECTION("!x")
+		{
+			TestType x{pal::unexpect, e1}, y{std::move(x)};
+			CHECK(y.error() == e1);
+		}
 	}
 
 	SECTION("expected(const expected<U, G> &)")
 	{
-		other_t x{v2};
-		TestType y{x};
-		CHECK(y.value() == v2);
+		SECTION("x")
+		{
+			other_t x{v2};
+			TestType y{x};
+			CHECK(y.value() == v2);
+		}
+
+		SECTION("!x")
+		{
+			other_t x{pal::unexpect, e2};
+			TestType y{x};
+			CHECK(y.error() == e2);
+		}
 	}
 
 	SECTION("expected(expected<U, G> &&)")
 	{
-		other_t x{v2};
-		TestType y{std::move(x)};
-		CHECK(y.value() == v2);
+		SECTION("x")
+		{
+			other_t x{v2};
+			TestType y{std::move(x)};
+			CHECK(y.value() == v2);
+		}
+
+		SECTION("!x")
+		{
+			other_t x{pal::unexpect, e2};
+			TestType y{std::move(x)};
+			CHECK(y.error() == e2);
+		}
 	}
 
 	SECTION("expected(U &&)")
@@ -1461,46 +1499,136 @@ TEMPLATE_TEST_CASE("expected", "",
 
 	SECTION("operator=(const expected &)")
 	{
-		TestType x, y{pal::unexpect, e1};
-		y = x;
-		CHECK(y.value() == T{});
+		SECTION("x && y")
+		{
+			TestType x, y{v1};
+			x = y;
+			CHECK(x.value() == v1);
+		}
+
+		SECTION("!x && y")
+		{
+			TestType x{pal::unexpect, e1}, y{v1};
+			x = y;
+			CHECK(x.value() == v1);
+		}
+
+		SECTION("x && !y")
+		{
+			TestType x, y{pal::unexpect, e1};
+			x = y;
+			CHECK(x.error() == e1);
+		}
+
+		SECTION("!x && !y")
+		{
+			TestType x{pal::unexpect, e1}, y{pal::unexpect, e2};
+			x = y;
+			CHECK(x.error() == e2);
+		}
 	}
 
 	SECTION("operator=(expected &&)")
 	{
-		TestType x, y{pal::unexpect, e1};
-		y = std::move(x);
-		CHECK(y.value() == T{});
+		SECTION("x && y")
+		{
+			TestType x, y{v1};
+			x = std::move(y);
+			CHECK(x.value() == v1);
+		}
+
+		SECTION("!x && y")
+		{
+			TestType x{pal::unexpect, e1}, y{v1};
+			x = std::move(y);
+			CHECK(x.value() == v1);
+		}
+
+		SECTION("x && !y")
+		{
+			TestType x, y{pal::unexpect, e1};
+			x = std::move(y);
+			CHECK(x.error() == e1);
+		}
+
+		SECTION("!x && !y")
+		{
+			TestType x{pal::unexpect, e1}, y{pal::unexpect, e2};
+			x = std::move(y);
+			CHECK(x.error() == e2);
+		}
 	}
 
 	SECTION("operator=(const unexpected<G> &)")
 	{
-		pal::unexpected<G> x{e2};
-		TestType y;
-		y = x;
-		CHECK(y.error() == e2);
+		SECTION("x")
+		{
+			TestType x;
+			pal::unexpected<G> y{e2};
+			x = y;
+			CHECK(x.error() == e2);
+		}
+
+		SECTION("!x")
+		{
+			TestType x{pal::unexpect, e1};
+			pal::unexpected<G> y{e2};
+			x = y;
+			CHECK(x.error() == e2);
+		}
 	}
 
 	SECTION("operator=(unexpected<G> &&)")
 	{
-		pal::unexpected<G> x{e2};
-		TestType y;
-		y = std::move(x);
-		CHECK(y.error() == e2);
+		SECTION("x")
+		{
+			TestType x;
+			pal::unexpected<G> y{e2};
+			x = std::move(y);
+			CHECK(x.error() == e2);
+		}
+
+		SECTION("!x")
+		{
+			TestType x{pal::unexpect, e1};
+			pal::unexpected<G> y{e2};
+			x = std::move(y);
+			CHECK(x.error() == e2);
+		}
 	}
 
 	SECTION("operator=(U &&)")
 	{
-		TestType x{v1};
-		x = std::move(v2);
-		CHECK(x.value() == v2);
+		SECTION("x")
+		{
+			TestType x{v1};
+			x = std::move(v2);
+			CHECK(x.value() == v2);
+		}
+
+		SECTION("!x")
+		{
+			TestType x{pal::unexpect, e1};
+			x = std::move(v2);
+			CHECK(x.value() == v2);
+		}
 	}
 
 	SECTION("emplace")
 	{
-		TestType x{v1};
-		CHECK(x.emplace(v2) == v2);
-		CHECK(x.value() == v2);
+		SECTION("x")
+		{
+			TestType x{v1};
+			CHECK(x.emplace(v2) == v2);
+			CHECK(x.value() == v2);
+		}
+
+		SECTION("!x")
+		{
+			TestType x{pal::unexpect, e1};
+			CHECK(x.emplace(v2) == v2);
+			CHECK(x.value() == v2);
+		}
 	}
 }
 
@@ -1531,28 +1659,66 @@ TEMPLATE_TEST_CASE("expected", "",
 
 	SECTION("expected(const expected &)")
 	{
-		TestType x, y{x};
-		CHECK(y);
+		SECTION("x")
+		{
+			TestType x, y{x};
+			CHECK(y);
+		}
+
+		SECTION("!x")
+		{
+			TestType x{pal::unexpect, e1}, y{x};
+			CHECK(y.error() == e1);
+		}
 	}
 
 	SECTION("expected(expected &&)")
 	{
-		TestType x, y{std::move(x)};
-		CHECK(y);
+		SECTION("x")
+		{
+			TestType x, y{std::move(x)};
+			CHECK(y);
+		}
+
+		SECTION("!x")
+		{
+			TestType x{pal::unexpect, e1}, y{std::move(x)};
+			CHECK(y.error() == e1);
+		}
 	}
 
 	SECTION("expected(const expected<U, G> &)")
 	{
-		other_t x;
-		TestType y{x};
-		CHECK(y);
+		SECTION("x")
+		{
+			other_t x;
+			TestType y{x};
+			CHECK(y);
+		}
+
+		SECTION("!x")
+		{
+			other_t x{pal::unexpect, e2};
+			TestType y{x};
+			CHECK(y.error() == e2);
+		}
 	}
 
 	SECTION("expected(expected<U, G> &&)")
 	{
-		other_t x;
-		TestType y{std::move(x)};
-		CHECK(y);
+		SECTION("x")
+		{
+			other_t x;
+			TestType y{std::move(x)};
+			CHECK(y);
+		}
+
+		SECTION("!x")
+		{
+			other_t x{pal::unexpect, e2};
+			TestType y{std::move(x)};
+			CHECK(y.error() == e2);
+		}
 	}
 
 	SECTION("expected(const unexpected<E> &)")
@@ -1597,39 +1763,119 @@ TEMPLATE_TEST_CASE("expected", "",
 
 	SECTION("operator=(const expected &)")
 	{
-		TestType x, y{pal::unexpect, e1};
-		y = x;
-		CHECK(y);
+		SECTION("x && y")
+		{
+			TestType x, y;
+			x = y;
+			CHECK(x);
+		}
+
+		SECTION("!x && y")
+		{
+			TestType x{pal::unexpect, e1}, y;
+			x = y;
+			CHECK(x);
+		}
+
+		SECTION("x && !y")
+		{
+			TestType x, y{pal::unexpect, e1};
+			x = y;
+			CHECK(!x);
+		}
+
+		SECTION("!x && !y")
+		{
+			TestType x{pal::unexpect, e1}, y{pal::unexpect, e1};
+			x = y;
+			CHECK(!x);
+		}
 	}
 
 	SECTION("operator=(expected &&)")
 	{
-		TestType x, y{pal::unexpect, e1};
-		y = std::move(x);
-		CHECK(y);
+		SECTION("x && y")
+		{
+			TestType x, y;
+			x = std::move(y);
+			CHECK(x);
+		}
+
+		SECTION("!x && y")
+		{
+			TestType x{pal::unexpect, e1}, y;
+			x = std::move(y);
+			CHECK(x);
+		}
+
+		SECTION("x && !y")
+		{
+			TestType x, y{pal::unexpect, e1};
+			x = std::move(y);
+			CHECK(!x);
+		}
+
+		SECTION("!x && !y")
+		{
+			TestType x{pal::unexpect, e1}, y{pal::unexpect, e1};
+			x = std::move(y);
+			CHECK(!x);
+		}
 	}
 
 	SECTION("operator=(const unexpected<G> &)")
 	{
-		pal::unexpected<G> x{e2};
-		TestType y;
-		y = x;
-		CHECK(y.error() == e2);
+		SECTION("x")
+		{
+			pal::unexpected<G> y{e2};
+			TestType x;
+			x = y;
+			CHECK(x.error() == e2);
+		}
+
+		SECTION("!x")
+		{
+			pal::unexpected<G> y{e2};
+			TestType x{pal::unexpect, e1};
+			x = y;
+			CHECK(x.error() == e2);
+		}
 	}
 
 	SECTION("operator=(unexpected<G> &&)")
 	{
-		pal::unexpected<G> x{e2};
-		TestType y;
-		y = std::move(x);
-		CHECK(y.error() == e2);
+		SECTION("x")
+		{
+			pal::unexpected<G> y{e2};
+			TestType x;
+			x = std::move(y);
+			CHECK(x.error() == e2);
+		}
+
+		SECTION("!x")
+		{
+			pal::unexpected<G> y{e2};
+			TestType x{pal::unexpect, e1};
+			x = std::move(y);
+			CHECK(x.error() == e2);
+		}
 	}
 
 	SECTION("emplace")
 	{
-		TestType x{pal::unexpect, e1};
-		x.emplace();
-		CHECK(x);
+		SECTION("x")
+		{
+			TestType x;
+			x.emplace();
+			CHECK(x);
+		}
+
+		SECTION("!x")
+		{
+			TestType x{pal::unexpect, e1};
+			x.emplace();
+			CHECK(x);
+		}
 	}
 }
 

--- a/pal/not_null
+++ b/pal/not_null
@@ -64,56 +64,18 @@ public:
 
 
 	/// Construct not_null from \a that
-	template <typename U,
-		std::enable_if_t<
-			std::is_constructible_v<Pointer, U>
-			&&
-			!std::is_convertible_v<U, Pointer>,
-			int
-		> = 0
-	>
-	constexpr explicit not_null (const not_null<U> &that)
-		: ptr_(that.as_nullable())
-	{ }
-
-
-	/// Construct not_null from \a that
-	template <typename U,
-		std::enable_if_t<
-			std::is_constructible_v<Pointer, U>
-			&&
-			!std::is_convertible_v<U, Pointer>
-			&&
-			!std::is_pointer_v<U>,
-			int
-		> = 0
-	>
-	constexpr explicit not_null (not_null<U> &&that)
-		: ptr_(std::move(that).as_nullable())
-	{ }
-
-
-	/// Construct not_null from \a that
-	template <typename U,
-		std::enable_if_t<
-			std::is_convertible_v<U, Pointer>,
-			int
-		> = 0
-	>
+	template <typename U>
+		requires(std::is_constructible_v<Pointer, U>)
+		explicit(!std::is_convertible_v<U, Pointer>)
 	constexpr not_null (const not_null<U> &that)
 		: ptr_(that.as_nullable())
 	{ }
 
 
 	/// Construct not_null from \a that
-	template <typename U,
-		std::enable_if_t<
-			std::is_convertible_v<U, Pointer>
-			&&
-			!std::is_pointer_v<U>,
-			int
-		> = 0
-	>
+	template <typename U>
+		requires(std::is_constructible_v<Pointer, U> && !std::is_pointer_v<U>)
+		explicit(!std::is_convertible_v<U, Pointer>)
 	constexpr not_null (not_null<U> &&that)
 		: ptr_(std::move(that).as_nullable())
 	{ }

--- a/pal/test
+++ b/pal/test
@@ -53,4 +53,106 @@ constexpr bool has_crypto_alloc_hook =
 ;
 
 
+constexpr uint16_t
+	nothrow				= 0b00'00'00'00'00'00'00'00,
+
+	default_ctor_can_throw		= 0b00'00'00'00'00'00'00'01,
+	default_ctor_throws		= 0b00'00'00'00'00'00'00'11,
+
+	emplace_ctor_can_throw		= 0b00'00'00'00'00'00'01'00,
+	emplace_ctor_throws		= 0b00'00'00'00'00'00'11'00,
+
+	copy_ctor_can_throw		= 0b00'00'00'00'00'01'00'00,
+	copy_ctor_throws		= 0b00'00'00'00'00'11'00'00,
+
+	move_ctor_can_throw		= 0b00'00'00'00'01'00'00'00,
+	move_ctor_throws		= 0b00'00'00'00'11'00'00'00,
+
+	emplace_assign_can_throw	= 0b00'00'00'01'00'00'00'00,
+	emplace_assign_throws		= 0b00'00'00'11'00'00'00'00,
+
+	copy_assign_can_throw		= 0b00'00'01'00'00'00'00'00,
+	copy_assign_throws		= 0b00'00'11'00'00'00'00'00,
+
+	move_assign_can_throw		= 0b00'01'00'00'00'00'00'00,
+	move_assign_throws		= 0b00'11'00'00'00'00'00'00,
+
+	ctor_can_throw			= default_ctor_can_throw
+					| emplace_ctor_can_throw
+					| copy_ctor_can_throw
+					| move_ctor_can_throw,
+
+	ctor_throws			= default_ctor_throws
+					| emplace_ctor_throws
+					| copy_ctor_throws
+					| move_ctor_throws;
+
+
+template <uint16_t ThrowControl>
+constexpr bool no_throw (uint16_t flag)
+{
+	return (ThrowControl & flag) == 0;
+}
+
+
+template <uint16_t ThrowControl>
+struct throwable
+{
+	bool value;
+
+	throwable () noexcept (no_throw<ThrowControl>(default_ctor_can_throw))
+		: value{false}
+	{
+		do_throw(ThrowControl, default_ctor_throws);
+	}
+
+	throwable (const throwable &that) noexcept(no_throw<ThrowControl>(copy_ctor_can_throw))
+		: value{that.value}
+	{
+		do_throw(ThrowControl, copy_ctor_throws);
+	}
+
+	throwable (throwable &&that) noexcept(no_throw<ThrowControl>(move_ctor_can_throw))
+		: value{that.value}
+	{
+		do_throw(ThrowControl, move_ctor_throws);
+	}
+
+	throwable (bool value) noexcept (no_throw<ThrowControl>(emplace_ctor_can_throw))
+		: value{value}
+	{
+		do_throw(ThrowControl, emplace_ctor_throws);
+	}
+
+	throwable &operator= (const throwable &that) noexcept(no_throw<ThrowControl>(copy_assign_can_throw))
+	{
+		value = that.value;
+		return do_throw(ThrowControl, copy_assign_throws);
+	}
+
+	throwable &operator= (throwable &&that) noexcept(no_throw<ThrowControl>(move_assign_can_throw))
+	{
+		value = std::move(that.value);
+		return do_throw(ThrowControl, move_assign_throws);
+	}
+
+	throwable &operator= (bool value) noexcept(no_throw<ThrowControl>(emplace_assign_can_throw))
+	{
+		this->value = value;
+		return do_throw(ThrowControl, emplace_assign_throws);
+	}
+
+private:
+
+	throwable &do_throw (uint16_t control, uint16_t flag)
+	{
+		if ((control & flag) == flag)
+		{
+			throw true;
+		}
+		return *this;
+	}
+};
+
+
 } // namespace pal_test

--- a/pal/test
+++ b/pal/test
@@ -82,6 +82,9 @@ constexpr uint16_t
 					| copy_ctor_can_throw
 					| move_ctor_can_throw,
 
+	copy_and_move_ctor_throws	= copy_ctor_throws
+					| move_ctor_throws,
+
 	ctor_throws			= default_ctor_throws
 					| emplace_ctor_throws
 					| copy_ctor_throws

--- a/pal/uninitialized
+++ b/pal/uninitialized
@@ -14,6 +14,16 @@ __pal_begin
 
 
 /**
+ * Tag type passed to uninitialized to indicate not to default construct
+ * internal storage
+ */
+struct no_init_t {};
+
+/// \see no_init_t
+constexpr no_init_t no_init{};
+
+
+/**
  * Uninitialized memory storage for typed variable.
  *
  * Provides memory block for \a T, not constructed during instantation of this
@@ -27,32 +37,38 @@ class uninitialized
 {
 public:
 
-	static_assert(!std::is_void_v<T>);
 	static_assert(!std::is_reference_v<T>);
+	static_assert(!std::is_same_v<std::remove_cv_t<T>, void>);
+	static_assert(!std::is_same_v<std::remove_cv_t<T>, no_init_t>);
+
+	/// Contained value type
+	using value_type = T;
 
 
-	using value_type = std::remove_const_t<T>;
-
-
+	/**
+	 * Default constructs variable T in internal storage.
+	 */
 	constexpr uninitialized () = default;
+
+
+	uninitialized (const uninitialized &) = delete;
+	uninitialized (uninitialized &&) = delete;
+	uninitialized &operator= (const uninitialized &) = delete;
+	uninitialized &operator= (uninitialized &&) = delete;
+
+
+	/**
+	 * No-op. It is application responsibility to destruct() T before this
+	 * object goes out of scope.
+	 */
 	~uninitialized () = default;
 
 
 	/**
-	 * Constructs variable \a T in internal storage with value from \a that.
+	 * Constructs uninitialized object without constructing variable \a T.
 	 */
-	constexpr uninitialized (const uninitialized &that)
-		noexcept(std::is_nothrow_copy_constructible_v<T>)
-		: storage_{that.get()}
-	{ }
-
-
-	/**
-	 * Constructs variable \a T in internal storage with value from \a that.
-	 */
-	constexpr uninitialized (uninitialized &&that)
-		noexcept(std::is_nothrow_move_constructible_v<T>)
-		: storage_{std::move(that.get())}
+	constexpr uninitialized (no_init_t tag) noexcept
+		: storage_{tag}
 	{ }
 
 
@@ -63,33 +79,12 @@ public:
 		requires(std::is_constructible_v<T, Args...>)
 	constexpr uninitialized (Args &&...args)
 		#if !defined(_MSC_BUILD)
-		noexcept(std::is_nothrow_constructible_v<T, Args...>)
+			noexcept(std::is_nothrow_constructible_v<T, Args...>)
 		#else
-		// TODO: error C2065: 'Args': undeclared identifier
+			// TODO: error C2065: 'Args': undeclared identifier
 		#endif
 		: storage_{std::forward<Args>(args)...}
 	{ }
-
-
-	/**
-	 * Constructs variable \a T in internal storage as copy of value
-	 * from \a that.
-	 */
-	void construct (const uninitialized<T> &that)
-		noexcept(std::is_nothrow_copy_constructible_v<T>)
-	{
-		::new (std::addressof(storage_)) value_type{that.get()};
-	}
-
-
-	/**
-	 * Constructs variable \a T in internal storage with value from \a that.
-	 */
-	void construct (uninitialized<T> &&that)
-		noexcept(std::is_nothrow_move_constructible_v<T>)
-	{
-		::new (std::addressof(storage_)) value_type{std::move(that.get())};
-	}
 
 
 	/**
@@ -100,7 +95,7 @@ public:
 	void construct (Args &&...args)
 		noexcept(std::is_nothrow_constructible_v<T, Args...>)
 	{
-		::new (std::addressof(storage_)) value_type{std::forward<Args>(args)...};
+		::new(std::addressof(storage_)) T{std::forward<Args>(args)...};
 	}
 
 
@@ -108,20 +103,30 @@ public:
 	 * Assign variable \a T in internal storage as copy of value
 	 * from \a that.
 	 */
-	void assign (const uninitialized<T> &that)
+	void assign (const T &that)
 		noexcept(std::is_nothrow_copy_assignable_v<T>)
+		#if !defined(__apple_build_version__)
+			requires(std::is_copy_assignable_v<T>)
+		#else
+			// TODO: expected ';' at end of declaration list
+		#endif
 	{
-		get() = that.get();
+		get() = that;
 	}
 
 
 	/**
 	 * Assign variable \a T in internal storage with value from \a that.
 	 */
-	void assign (uninitialized<T> &&that)
+	void assign (T &&that)
 		noexcept(std::is_nothrow_move_assignable_v<T>)
+		#if !defined(__apple_build_version__)
+			requires(std::is_move_assignable_v<T>)
+		#else
+			// TODO: expected ';' at end of declaration list
+		#endif
 	{
-		get() = std::move(that.get());
+		get() = std::move(that);
 	}
 
 
@@ -129,7 +134,7 @@ public:
 	 * Invokes T destructor in memory block. No-op for trivially
 	 * destructible type T
 	 */
-	constexpr void destruct ()
+	void destruct ()
 		noexcept(std::is_nothrow_destructible_v<T>)
 	{
 		storage_.value.~value_type();
@@ -231,58 +236,60 @@ private:
 	template <typename U, bool = std::is_trivially_destructible_v<U>>
 	union storage
 	{
-		bool empty;
 		U value;
+		no_init_t empty;
 
 		constexpr storage () noexcept
-			: empty{}
-		{ }
-
-		constexpr storage (const U &that)
-			noexcept(std::is_nothrow_copy_constructible_v<U>)
-			: value{that}
-		{ }
-
-		constexpr storage (U &&that)
-			noexcept(std::is_nothrow_move_constructible_v<U>)
-			: value{std::move(that)}
+			: value{}
 		{ }
 
 		template <typename... Args>
+			requires(std::is_constructible_v<U, Args &&...>)
 		constexpr storage (Args &&...args)
-			noexcept(std::is_nothrow_constructible_v<U, Args...>)
+			noexcept(std::is_nothrow_constructible_v<U, Args &&...>)
 			: value{std::forward<Args>(args)...}
 		{ }
+
+		constexpr storage (no_init_t tag) noexcept
+			: empty{tag}
+		{ }
+
+		~storage () = default;
+
+		storage (const storage &) = delete;
+		storage (storage &&) = delete;
+		storage &operator= (const storage &) = delete;
+		storage &operator= (storage &&) = delete;
 	};
 
 	template <typename U>
 	union storage<U, false>
 	{
-		bool empty;
 		U value;
+		no_init_t empty;
 
 		constexpr storage () noexcept
-			: empty{}
-		{ }
-
-		constexpr storage (const U &that)
-			noexcept(std::is_nothrow_copy_constructible_v<U>)
-			: value{that}
-		{ }
-
-		constexpr storage (U &&that)
-			noexcept(std::is_nothrow_move_constructible_v<U>)
-			: value{std::move(that)}
+			: value{}
 		{ }
 
 		template <typename... Args>
+			requires(std::is_constructible_v<U, Args &&...>)
 		constexpr storage (Args &&...args)
-			noexcept(std::is_nothrow_constructible_v<U, Args...>)
+			noexcept(std::is_nothrow_constructible_v<U, Args &&...>)
 			: value{std::forward<Args>(args)...}
+		{ }
+
+		constexpr storage (no_init_t tag) noexcept
+			: empty{tag}
 		{ }
 
 		~storage ()
 		{ }
+
+		storage (const storage &) = delete;
+		storage (storage &&) = delete;
+		storage &operator= (const storage &) = delete;
+		storage &operator= (storage &&) = delete;
 	};
 
 	storage<value_type> storage_{};

--- a/pal/uninitialized
+++ b/pal/uninitialized
@@ -13,71 +13,6 @@
 __pal_begin
 
 
-template <typename T, bool = std::is_trivially_destructible_v<T>>
-struct uninitialized_storage;
-
-
-/**
- * Storage for uninitialized<T> memory block.
- */
-template <typename T>
-struct uninitialized_storage<T, true>
-{
-	/// Memory block for storage
-	T data;
-
-	/**
-	 * Invokes T destructor in memory block. No-op for trivially
-	 * destructible type T
-	 */
-	constexpr void destruct () noexcept
-	{ }
-
-
-	/// Returns pointer to memory block
-	constexpr const T *operator-> () const noexcept
-	{
-		return &data;
-	}
-
-
-	/// Returns pointer to memory block
-	constexpr T *operator-> () noexcept
-	{
-		return &data;
-	}
-};
-
-
-#if !defined(__DOXYGEN__)
-
-template <typename T>
-struct uninitialized_storage<T, false>
-{
-	std::aligned_storage_t<sizeof(T)> data;
-
-
-	void destruct () noexcept(std::is_nothrow_destructible_v<T>)
-	{
-		operator->()->~T();
-	}
-
-
-	const T *operator-> () const noexcept
-	{
-		return reinterpret_cast<const T *>(&data);
-	}
-
-
-	T *operator-> () noexcept
-	{
-		return reinterpret_cast<T *>(&data);
-	}
-};
-
-#endif
-
-
 /**
  * Uninitialized memory storage for typed variable.
  *
@@ -88,91 +23,272 @@ struct uninitialized_storage<T, false>
  * is not constructed yet or is already destructed is undefined behaviour.
  */
 template <typename T>
-struct uninitialized: public uninitialized_storage<T>
+class uninitialized
 {
-	using uninitialized_storage<T>::operator->;
+public:
+
+	static_assert(!std::is_void_v<T>);
+	static_assert(!std::is_reference_v<T>);
 
 
-	/// Constructs variable \a T in internal \a storage as default value.
-	constexpr void construct ()
+	using value_type = std::remove_const_t<T>;
+
+
+	constexpr uninitialized () = default;
+	~uninitialized () = default;
+
+
+	/**
+	 * Constructs variable \a T in internal storage with value from \a that.
+	 */
+	constexpr uninitialized (const uninitialized &that)
+		noexcept(std::is_nothrow_copy_constructible_v<T>)
+		: storage_{that.get()}
+	{ }
+
+
+	/**
+	 * Constructs variable \a T in internal storage with value from \a that.
+	 */
+	constexpr uninitialized (uninitialized &&that)
+		noexcept(std::is_nothrow_move_constructible_v<T>)
+		: storage_{std::move(that.get())}
+	{ }
+
+
+	/**
+	 * Constructs variable \a T in internal storage with \a args.
+	 */
+	template <typename... Args>
+		requires(std::is_constructible_v<T, Args...>)
+	constexpr uninitialized (Args &&...args)
+		#if !defined(_MSC_BUILD)
+		noexcept(std::is_nothrow_constructible_v<T, Args...>)
+		#else
+		// TODO: error C2065: 'Args': undeclared identifier
+		#endif
+		: storage_{std::forward<Args>(args)...}
+	{ }
+
+
+	/**
+	 * Constructs variable \a T in internal storage as copy of value
+	 * from \a that.
+	 */
+	void construct (const uninitialized<T> &that)
+		noexcept(std::is_nothrow_copy_constructible_v<T>)
 	{
-		::new (operator->()) T;
+		::new (std::addressof(storage_)) value_type{that.get()};
 	}
 
 
-	/// Constructs variable \a T in internal \a storage as copy of \a arg
-	constexpr void construct (const T &arg)
+	/**
+	 * Constructs variable \a T in internal storage with value from \a that.
+	 */
+	void construct (uninitialized<T> &&that)
+		noexcept(std::is_nothrow_move_constructible_v<T>)
 	{
-		::new (operator->()) T(arg);
+		::new (std::addressof(storage_)) value_type{std::move(that.get())};
 	}
 
 
-	/// Constructs variable \a T in internal \a storage with \a args
-	template <
-		typename... Args,
-		typename = std::enable_if_t<std::is_constructible_v<T, Args...>>
-	>
-	constexpr void construct (Args &&...args)
+	/**
+	 * Constructs variable \a T in internal \a storage with \a args.
+	 */
+	template <typename... Args>
+		requires(std::is_constructible_v<T, Args...>)
+	void construct (Args &&...args)
+		noexcept(std::is_nothrow_constructible_v<T, Args...>)
 	{
-		::new (operator->()) T(std::forward<Args>(args)...);
+		::new (std::addressof(storage_)) value_type{std::forward<Args>(args)...};
 	}
 
 
-	/// Returns const reference to variable \a T.
+	/**
+	 * Assign variable \a T in internal storage as copy of value
+	 * from \a that.
+	 */
+	void assign (const uninitialized<T> &that)
+		noexcept(std::is_nothrow_copy_assignable_v<T>)
+	{
+		get() = that.get();
+	}
+
+
+	/**
+	 * Assign variable \a T in internal storage with value from \a that.
+	 */
+	void assign (uninitialized<T> &&that)
+		noexcept(std::is_nothrow_move_assignable_v<T>)
+	{
+		get() = std::move(that.get());
+	}
+
+
+	/**
+	 * Invokes T destructor in memory block. No-op for trivially
+	 * destructible type T
+	 */
+	constexpr void destruct ()
+		noexcept(std::is_nothrow_destructible_v<T>)
+	{
+		storage_.value.~value_type();
+	}
+
+
+	/**
+	 * Returns const reference to variable \a T.
+	 */
+	constexpr const T &get () const & noexcept
+	{
+		return storage_.value;
+	}
+
+
+	/**
+	 * Returns reference to variable \a T.
+	 */
+	constexpr T &get () & noexcept
+	{
+		return storage_.value;
+	}
+
+
+	/**
+	 * Returns const rvalue reference to variable \a T.
+	 */
+	constexpr const T &&get () const && noexcept
+	{
+		return std::move(storage_.value);
+	}
+
+
+	/**
+	 * Returns rvalue reference to variable \a T.
+	 */
+	constexpr T &&get () && noexcept
+	{
+		return std::move(storage_.value);
+	}
+
+
+	/**
+	 * Returns const reference to variable \a T.
+	 */
 	constexpr const T &operator* () const & noexcept
 	{
-		return *operator->();
+		return get();
 	}
 
 
-	/// Returns reference to variable \a T.
+	/**
+	 * Returns reference to variable \a T.
+	 */
 	constexpr T &operator* () & noexcept
 	{
-		return *operator->();
+		return get();
 	}
 
 
-	/// Return const rvalue reference to variable \a T.
+	/**
+	 * Returns const rvalue reference to variable \a T.
+	 */
 	constexpr const T &&operator* () const && noexcept
 	{
-		return std::move(*operator->());
+		return std::move(get());
 	}
 
 
-	/// Return rvalue reference to variable \a T.
+	/**
+	 * Returns rvalue reference to variable \a T.
+	 */
 	constexpr T &&operator* () && noexcept
 	{
-		return std::move(*operator->());
+		return std::move(get());
 	}
 
 
-	/// Returns const reference to variable \a T.
-	constexpr const T &value () const & noexcept
+	/**
+	 * Returns const pointer to variable \a T.
+	 */
+	constexpr const T *operator-> () const noexcept
 	{
-		return *operator->();
+		return std::addressof(get());
 	}
 
 
-	/// Returns reference to variable \a T.
-	constexpr T &value () & noexcept
+	/**
+	 * Returns const pointer to variable \a T.
+	 */
+	constexpr T *operator-> () noexcept
 	{
-		return *operator->();
+		return std::addressof(get());
 	}
 
 
-	/// Return const rvalue reference to variable \a T.
-	constexpr const T &&value () const && noexcept
+private:
+
+	template <typename U, bool = std::is_trivially_destructible_v<U>>
+	union storage
 	{
-		return std::move(*operator->());
-	}
+		bool empty;
+		U value;
 
+		constexpr storage () noexcept
+			: empty{}
+		{ }
 
-	/// Return rvalue reference to variable \a T.
-	constexpr T &&value () && noexcept
+		constexpr storage (const U &that)
+			noexcept(std::is_nothrow_copy_constructible_v<U>)
+			: value{that}
+		{ }
+
+		constexpr storage (U &&that)
+			noexcept(std::is_nothrow_move_constructible_v<U>)
+			: value{std::move(that)}
+		{ }
+
+		template <typename... Args>
+		constexpr storage (Args &&...args)
+			noexcept(std::is_nothrow_constructible_v<U, Args...>)
+			: value{std::forward<Args>(args)...}
+		{ }
+	};
+
+	template <typename U>
+	union storage<U, false>
 	{
-		return std::move(*operator->());
-	}
+		bool empty;
+		U value;
+
+		constexpr storage () noexcept
+			: empty{}
+		{ }
+
+		constexpr storage (const U &that)
+			noexcept(std::is_nothrow_copy_constructible_v<U>)
+			: value{that}
+		{ }
+
+		constexpr storage (U &&that)
+			noexcept(std::is_nothrow_move_constructible_v<U>)
+			: value{std::move(that)}
+		{ }
+
+		template <typename... Args>
+		constexpr storage (Args &&...args)
+			noexcept(std::is_nothrow_constructible_v<U, Args...>)
+			: value{std::forward<Args>(args)...}
+		{ }
+
+		~storage ()
+		{ }
+	};
+
+	storage<value_type> storage_{};
 };
+
+template <typename T> uninitialized(T) -> uninitialized<T>;
 
 
 __pal_end


### PR DESCRIPTION
* Make pal::expected<T,E> truly constexpr.
* std::enable_if_t -> requires()